### PR TITLE
Add quiet option that only prints errors.

### DIFF
--- a/bin/coffeelint
+++ b/bin/coffeelint
@@ -165,12 +165,17 @@ CoffeeLint is freely distributable under the MIT license.
     };
 
     Reporter.prototype.reportPath = function(path, errors) {
-      var color, e, msg, o, overall, _i, _len, _ref, _results;
-      _ref = this.errorReport.pathHasError(path) ? [this.err, 'red'] : this.errorReport.pathHasWarning(path) ? [this.warn, 'yellow'] : [this.ok, 'green'], overall = _ref[0], color = _ref[1];
-      this.print("  " + overall + " " + (this.stylize(path, color, 'bold')));
+      var color, e, hasError, hasWarning, msg, o, overall, _i, _len, _ref, _results;
+      _ref = (hasError = this.errorReport.pathHasError(path)) ? [this.err, 'red'] : (hasWarning = this.errorReport.pathHasWarning(path)) ? [this.warn, 'yellow'] : [this.ok, 'green'], overall = _ref[0], color = _ref[1];
+      if (!(options.argv.q || hasError)) {
+        this.print("  " + overall + " " + (this.stylize(path, color, 'bold')));
+      }
       _results = [];
       for (_i = 0, _len = errors.length; _i < _len; _i++) {
         e = errors[_i];
+        if (options.argv.q && e.level !== 'error') {
+          continue;
+        }
         o = e.level === 'error' ? this.err : this.warn;
         msg = "     " + ("" + o + " " + (this.stylize("#" + e.lineNumber, color)) + ": " + e.message + ".");
         if (e.context) {
@@ -305,7 +310,7 @@ CoffeeLint is freely distributable under the MIT license.
     return process.exit(errorReport.getExitCode());
   };
 
-  options = optimist.usage("Usage: coffeelint [options] source [...]").alias("f", "file").alias("h", "help").alias("v", "version").alias("s", "stdin").describe("f", "Specify a custom configuration file.").describe("h", "Print help information.").describe("v", "Print current version number.").describe("r", "Recursively lint .coffee files in subdirectories.").describe("csv", "Use the csv reporter.").describe("jslint", "Use the JSLint XML reporter.").describe("s", "Lint the source from stdin").boolean("csv").boolean("jshint").boolean("r").boolean("s");
+  options = optimist.usage("Usage: coffeelint [options] source [...]").alias("f", "file").alias("h", "help").alias("v", "version").alias("s", "stdin").describe("f", "Specify a custom configuration file.").describe("h", "Print help information.").describe("v", "Print current version number.").describe("r", "Recursively lint .coffee files in subdirectories.").describe("csv", "Use the csv reporter.").describe("jslint", "Use the JSLint XML reporter.").describe("s", "Lint the source from stdin").boolean("csv").boolean("jshint").boolean("r").boolean("s").boolean("q", "Print errors only.");
 
   if (options.argv.v) {
     console.log(coffeelint.VERSION);

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -110,14 +110,16 @@ class Reporter
         @print "\n" + @stylize(msg)
 
     reportPath : (path, errors) ->
-        [overall, color] = if @errorReport.pathHasError(path)
+        [overall, color] = if hasError = @errorReport.pathHasError(path)
             [@err, 'red']
-        else if @errorReport.pathHasWarning(path)
+        else if hasWarning = @errorReport.pathHasWarning(path)
             [@warn, 'yellow']
         else
             [@ok, 'green']
-        @print "  #{overall} #{@stylize(path, color, 'bold')}"
+        unless options.argv.q or hasError
+            @print "  #{overall} #{@stylize(path, color, 'bold')}"
         for e in errors
+            continue if options.argv.q and e.level != 'error'
             o = if e.level == 'error' then @err else @warn
             msg = "     " +
                     "#{o} #{@stylize("#" + e.lineNumber, color)}: #{e.message}."
@@ -221,6 +223,7 @@ options = optimist
             .boolean("jshint")
             .boolean("r")
             .boolean("s")
+            .boolean("q", "Print errors only.")
 
 if options.argv.v
     console.log coffeelint.VERSION


### PR DESCRIPTION
You may have something better coming, but in the meantime this is what we've been using to deal with large amounts of files on our CI machine.  Printing files that are ok or have warnings makes it very difficult to find the errors (especially if there are many ok/warning files).

If you'd rather I didn't compile before submitting, just let me know and I'll make the change.
