### PR TITLE
Fix typo in implicit brace rule example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ myFunction(a, b, {1:2, 3:4})
                   <td class="description">
     This rule prohibits implicit parens on function calls.
 <pre>
-<code># Some folks don't like this style of coding. style of coding.
+<code># Some folks don't like this style of coding.
 myFunction a, b, c
 
 # And would rather it always be written like this:


### PR DESCRIPTION
Removing an extra sentence fragment "style of coding."
