### PR TITLE
Parse coffeescript AST errors beyond line 10.

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -576,7 +576,7 @@ class ASTLinter
 
         # Parse the line number
         lineNumber = -1
-        match = /line (\d)/.exec message
+        match = /line (\d+)/.exec message
         lineNumber = parseInt match[1], 10 if match?.length > 1
         attrs = {
             message: message


### PR DESCRIPTION
Just a mior adjustment of the line number matcher
