### PR TITLE
Add check for empty parameter lists.

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -91,6 +91,10 @@ RULES =
         level : IGNORE
         message : 'Implicit parens are forbidden'
 
+    empty_param_list :
+        level : IGNORE
+        message : 'Empty parameter list is forbidden'
+
     space_operators :
         level : IGNORE
         message : 'Operators must be spaced properly'
@@ -374,6 +378,7 @@ class LexicalLinter
             when "(", ")"                 then @lintParens(token)
             when "JS"                     then @lintJavascript(token)
             when "CALL_START", "CALL_END" then @lintCall(token)
+            when "PARAM_START"            then @lintParam(token)
             when "@"                      then @lintStandaloneAt(token)
             when "+", "-"                 then @lintPlus(token)
             when "=", "MATH", "COMPARE", "LOGIC"
@@ -453,6 +458,13 @@ class LexicalLinter
         else
             @callTokens.pop()
             return null
+
+    lintParam : (token) ->
+        nextType = @peek()[0]
+        if nextType == 'PARAM_END'
+            @createLexError('empty_param_list')
+        else
+            null
 
     lintBrace : (token) ->
         if token.generated

--- a/test/test_empty_param_list.coffee
+++ b/test/test_empty_param_list.coffee
@@ -1,0 +1,30 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+vows.describe('params').addBatch({
+
+    'Empty param list' :
+
+        topic : () ->
+            '''
+            blah = () ->
+            '''
+
+        'are allowed by default' : (source) ->
+            errors = coffeelint.lint(source)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+        'can be forbidden' : (source) ->
+            config = {empty_param_list : {level:'error'}}
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+            error = errors[0]
+            assert.equal(error.lineNumber, 1)
+            assert.equal(error.message, 'Empty parameter list is forbidden')
+            assert.equal(error.rule, 'empty_param_list')
+
+}).export(module)


### PR DESCRIPTION
`foo = () ->` can be written more simply as `foo = ->`.
