### PR TITLE
Added an exception to exclude errors caused by long URLS in comments.

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -117,6 +117,11 @@ coffeelint.RULES = RULES =
 regexes =
     trailingWhitespace : /[^\s]+[\t ]+\r?$/
     indentation: /\S/
+    longUrlComment: ///
+      ^\s*\# # indentation, up to comment
+      \s*
+      http[^\s]+$ # Link that takes up the rest of the line without spaces.
+    ///
     camelCase: /^[A-Z][a-zA-Z\d]*$/
     trailingSemicolon: /;\r?$/
     configStatement: /coffeelint:\s*(disable|enable)(?:=([\w\s,]*))?/
@@ -219,7 +224,7 @@ class LineLinter
         rule = 'max_line_length'
         max = @config[rule]?.value
         if max and max < @line.length
-            @createLineError(rule)
+            @createLineError(rule) unless regexes.longUrlComment.test(@line)
         else
             null
 

--- a/test/test_line_length.coffee
+++ b/test/test_line_length.coffee
@@ -39,4 +39,17 @@ vows.describe('linelength').addBatch({
                 errors = coffeelint.lint(source, config)
                 assert.isEmpty(errors)
 
+    'Maximum length exceptions':
+        topic: """
+            # Since the line length check only reads lines in isolation it will
+            # see the following line as a comment even though it's in a string.
+            # I don't think that's a problem.
+            #
+            # http://testing.example.com/really-really-long-url-that-shouldnt-have-to-be-split-to-avoid-the-lint-error
+        """
+
+        'excludes long urls': (source) ->
+            errors = coffeelint.lint(source)
+            assert.isEmpty(errors)
+
 }).export(module)


### PR DESCRIPTION
I often have long urls in comments and it doesn't make sense to require splitting them into multiple lines. With this branch when a line is a comment containing only a URL it's allowed to go over the line length.
