### PR TITLE
Warn on missing parentheses after "new Foo".

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -93,8 +93,8 @@ coffeelint.RULES = RULES =
         message : 'Implicit parens are forbidden'
 
     missing_new_parens :
-        level : WARN
-        message : 'Invoking a constructor without parens'
+        level : IGNORE
+        message : 'Invoking a constructor without parens and without arguments'
 
     no_empty_param_list :
         level : IGNORE

--- a/test/test_missing_parens_on_new.coffee
+++ b/test/test_missing_parens_on_new.coffee
@@ -17,7 +17,10 @@ vows.describe('newparens').addBatch({
             """
 
         'defaults to warning about missing parens': (source) ->
-            errors = coffeelint.lint(source)
+            config =
+                missing_new_parens:
+                    level: 'error'
+            errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 1)
             error = errors[0]
             assert.equal(error.lineNumber, 3)


### PR DESCRIPTION
This adds a new rule, `missing_new_parens`, that will warn when parentheses (implied or explicit) are not present after building an instance from a constructor using `new`.
