### PR TITLE
(non_)empty_constructor_needs_parens rule fails incorrectly when constructing a chained class name

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -374,8 +374,7 @@ class LineLinter
         null
 
 #
-# A class that performs checks on the output of CoffeeScript's
-# lexer.
+# A class that performs checks on the output of CoffeeScript's lexer.
 #
 class LexicalLinter
 
@@ -401,8 +400,7 @@ class LexicalLinter
             errors.push(error) if error
         errors
 
-    # Return an error if the given token fails a lint check, false
-    # otherwise.
+    # Return an error if the given token fails a lint check, false otherwise.
     lintToken : (token) ->
         [type, value, lineNumber] = token
 
@@ -435,11 +433,20 @@ class LexicalLinter
 
     lintUnary: (token) ->
         if token[1] is 'new'
-            expectedIdentifier = @peek(1)
+            # Find the last chained identifier, e.g. Bar in new foo.bar.Bar().
+            identifierIndex = 1
+            loop
+                expectedIdentifier = @peek(identifierIndex)
+                expectedCallStart  = @peek(identifierIndex + 1)
+                if expectedIdentifier?[0] is 'IDENTIFIER'
+                    if expectedCallStart?[0] is '.'
+                        identifierIndex += 2
+                        continue
+                break
+
             # The callStart is generated if your parameters are all on the same
             # line with implicit parens, and if your parameters start on the
             # next line, but is missing if there are no params and no parens.
-            expectedCallStart  = @peek(2)
             if expectedIdentifier?[0] is 'IDENTIFIER' and expectedCallStart?
                 if expectedCallStart[0] is 'CALL_START'
                     if expectedCallStart.generated

--- a/test/test_constructor_needs_parens.coffee
+++ b/test/test_constructor_needs_parens.coffee
@@ -13,11 +13,14 @@ vows.describe('newparens').addBatch({
 
             # Warn about missing parens here
             a = new Foo
+            b = new bar.foo.Foo
             # The parens make it clear no parameters are intended
-            b = new Foo()
-            c = new Foo 1, 2
+            c = new Foo()
+            d = new bar.foo.Foo()
+            e = new Foo 1, 2
+            f = new bar.foo.Foo 1, 2
             # Since this does have a parameter it should not require parens
-            d = new Foo
+            g = new bar.foo.Foo
               config: 'parameter'
             """
 
@@ -26,10 +29,11 @@ vows.describe('newparens').addBatch({
                 empty_constructor_needs_parens:
                     level: 'error'
             errors = coffeelint.lint(source, config)
-            assert.equal(errors.length, 1)
-            error = errors[0]
-            assert.equal(error.lineNumber, 4)
-            assert.equal(error.rule, 'empty_constructor_needs_parens')
+            assert.equal(errors.length, 2)
+            assert.equal(errors[0].lineNumber, 4)
+            assert.equal(errors[0].rule, 'empty_constructor_needs_parens')
+            assert.equal(errors[1].lineNumber, 5)
+            assert.equal(errors[1].rule, 'empty_constructor_needs_parens')
 
     'Missing Parentheses on "new Foo 1, 2"' :
 
@@ -43,9 +47,16 @@ vows.describe('newparens').addBatch({
             c = new Foo 1, 2
             d = new Foo
               config: 'parameter'
+            e = new bar.foo.Foo 1, 2
+            f = new bar.foo.Foo
+              config: 'parameter'
             # But not here
-            e = new Foo(1, 2)
-            f = new Foo(
+            g = new Foo(1, 2)
+            h = new Foo(
+              config: 'parameter'
+            )
+            i = new bar.foo.Foo(1, 2)
+            j = new bar.foo.Foo(
               config: 'parameter'
             )
             """
@@ -55,10 +66,14 @@ vows.describe('newparens').addBatch({
                 non_empty_constructor_needs_parens:
                     level: 'error'
             errors = coffeelint.lint(source, config)
-            assert.equal(errors.length, 2)
+            assert.equal(errors.length, 4)
             assert.equal(errors[0].lineNumber, 6)
             assert.equal(errors[0].rule, 'non_empty_constructor_needs_parens')
             assert.equal(errors[1].lineNumber, 7)
             assert.equal(errors[1].rule, 'non_empty_constructor_needs_parens')
+            assert.equal(errors[2].lineNumber, 9)
+            assert.equal(errors[2].rule, 'non_empty_constructor_needs_parens')
+            assert.equal(errors[3].lineNumber, 10)
+            assert.equal(errors[3].rule, 'non_empty_constructor_needs_parens')
 
 }).export(module)


### PR DESCRIPTION
e.g. `new bar.foo.Foo()`

This change could use some scrutiny by a compiler-y person -- we need a way to find the final identifier/class name of the `new`. There are probably more expressions that are possible that would incorrectly fail.
