### PR TITLE
Add optional lint for '&&', '||', '==', '!='

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -133,6 +133,14 @@ coffeelint.RULES = RULES =
         level : ERROR
         message : '' # The default coffeescript error is fine.
 
+    idomatic_and_or:
+        level : IGNORE
+        message : 'Ensure that idomatic operators are used for && and ||.'
+
+    idomatic_is_isnt:
+        level : IGNORE
+        message : 'Ensure that idomatic operators are used for == and !=.'
+
 
 # Some repeatedly used regular expressions.
 regexes =
@@ -511,6 +519,8 @@ class LexicalLinter
     lintMath: (token) ->
         if not token.spaced and not token.newLine
             @createLexError('space_operators', {context: token[1]})
+        else if token[1] in ['==', '!=', '&&', '||']
+            @lintIdomaticOperators(token)
         else
             null
 
@@ -709,6 +719,13 @@ class LexicalLinter
             @createLexError('arrow_spacing')
         else
             null
+
+    lintIdomaticOperators : (token) ->
+        switch token[1]
+            when '==', "!="
+                @createLexError("idomatic_is_isnt")
+            when '&&', '||'
+                @createLexError("idomatic_and_or")
 
     createLexError : (rule, attrs = {}) ->
         attrs.lineNumber = @lineNumber + 1

--- a/test/test_operators.coffee
+++ b/test/test_operators.coffee
@@ -1,0 +1,48 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+vows.describe('operators').addBatch({
+
+    'Coffeescript and or is isnt' :
+
+        topic : () ->
+            '''
+            foo == bar
+            foo != bar
+            foo && bar
+            foo || bar
+            '''
+
+        'are allowed by default' : (source) ->
+            errors = coffeelint.lint(source)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+        'can forbid is and isnt' : (source) ->
+            config =
+                idomatic_is_isnt: {level: 'error'}
+
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 2)
+            error = errors[0]
+            assert.equal(error.lineNumber, 1)
+            msg = 'Ensure that idomatic operators are used for == and !=.'
+            assert.equal(error.message, msg)
+            assert.equal(error.rule, 'idomatic_is_isnt')
+
+        'can forbid and or' : (source) ->
+            config =
+                idomatic_and_or: {level: 'error'}
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 2)
+            error = errors[0]
+            assert.equal(error.lineNumber, 3)
+            msg = 'Ensure that idomatic operators are used for && and ||.'
+            assert.equal(error.message, msg)
+            assert.equal(error.rule, 'idomatic_and_or')
+
+}).export(module)


### PR DESCRIPTION
Pretty basic pull request. Add two new additional rules which are optional by default: 

`idomatic_and_or`
and
`idomatic_is_isnt`. 

Thanks! 
