### PR TITLE
Drop 2nd param from optimist#boolean()

### DIFF
--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -236,7 +236,7 @@ options = optimist
             .boolean("makeconfig")
             .boolean("r")
             .boolean("s")
-            .boolean("q", "Print errors only.")
+            .boolean("q")
 
 if options.argv.v
     console.log coffeelint.VERSION


### PR DESCRIPTION
There is no second parameter for optimist#boolean(). See [substack/node-optimist/readme.markdown#booleankey](https://github.com/substack/node-optimist/blob/d4e1f6effc0ba0f7c01f889c48823a0429f036d3/readme.markdown#booleankey).
