### PR TITLE
Add simple bin/coffeelint wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin/*
 lib/*
 node_modules
 *.log

--- a/bin/coffeelint
+++ b/bin/coffeelint
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/commandline')

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "test": "vows --spec test/*.coffee",
     "posttest": "npm run lint",
     "prepublish": "npm run compile",
-    "preinstall": "[ -e bin/coffeelint ] || (which coffee && npm run compile) || true",
+    "install": "[ -e lib/commandline.js ] || npm run compile",
     "lint": "npm run compile && ./bin/coffeelint -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee",
     "lint-csv": "npm run compile && ./bin/coffeelint --csv -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee",
     "lint-jslint": "npm run compile && ./bin/coffeelint --jslint -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee",
-    "compile": "coffee -c -o lib src && mkdir -p bin && echo '#!/usr/bin/env node' | cat - lib/commandline.js > bin/coffeelint && chmod +x bin/coffeelint && rm lib/commandline.js"
+    "compile": "coffee -c -o lib src"
   }
 }


### PR DESCRIPTION
This means that the `bin/coffeelint` executable doesn't need to be created each time.

At least... That's the hope.
