### PR TITLE
Fix multiple chained indent with inlined callbacks

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -923,10 +923,14 @@ class LexicalLinter
         return false if not lastNewLineIndex?
 
         # Otherwise, figure out if that token or the next is an attribute
-        # look-up.
+        # look-up or a call end.
         tokens = [@tokens[lastNewLineIndex], @tokens[lastNewLineIndex + 1]]
 
-        return !!(t for t in tokens when t and t[0] == '.').length
+        for t in tokens
+            if t and (t[0] == '.' or t[0] == 'CALL_END')
+                return true
+
+        return false
 
 
 # A class that performs static analysis of the abstract

--- a/test/test_indent.coffee
+++ b/test/test_indent.coffee
@@ -184,6 +184,26 @@ vows.describe('indent').addBatch({
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
+    'Multiple indented chained invocations with inlined callbacks' :
+        topic : () ->
+            """
+            obj()
+                .r ->
+                    foo()
+                .s ->
+                    bar()
+
+                .t ->
+                    baz()
+            """
+        'should not result in an error' : (source) ->
+            config =
+                indentation:
+                    value: 4
+            errors = coffeelint.lint(source, config)
+            assert.isEmpty(errors)
+
+
     'Arbitrarily indented arguments' :
 
         topic : """


### PR DESCRIPTION
Updates @isChainedCall to also treat "CALL_END" the same as an attribute
lookup.
