### PR TITLE
Fix operator_spacing returning an error when using 'by -1' in a for loop

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -673,7 +673,7 @@ class LexicalLinter
         unaries = ['TERMINATOR', '(', '=', '-', '+', ',', 'CALL_START',
                     'INDEX_START', '..', '...', 'COMPARE', 'IF',
                     'THROW', 'LOGIC', 'POST_IF', ':', '[', 'INDENT',
-                    'COMPOUND_ASSIGN', 'RETURN', 'MATH']
+                    'COMPOUND_ASSIGN', 'RETURN', 'MATH', 'BY']
         isUnary = if not p then false else p[0] in unaries
         if (isUnary and token.spaced) or
                     (not isUnary and not token.spaced and not token.newLine)

--- a/test/test_spacing.coffee
+++ b/test/test_spacing.coffee
@@ -100,6 +100,7 @@ vows.describe('spacing').addBatch({
             -a *= -b
             a * -b
             return -1
+            for x in xs by -1 then x
             '''
 
         'are permitted' : (source) ->


### PR DESCRIPTION
Currently, when using operator_spacing, 'by -1' in a for loop causes an error. This fixes that.
