### PR TITLE
Support `literate` as option to `lint`

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -1061,7 +1061,7 @@ coffeelint.invertLiterate = (source) ->
 #       context:    'Optional details about why the rule was violated'
 #   }
 #
-coffeelint.lint = (source, userConfig = {}, literate = false) ->
+coffeelint.lint = (source, userConfig = {}, literate = userConfig.literate) ->
     source = @invertLiterate source if literate
 
     config = mergeDefaultConfig(userConfig)


### PR DESCRIPTION
This improves programmatic integration, i.e. `grunt-contrib-coffeelint`. There are probably some other ways to do it, this seemed the most idiomatic.
