### PR TITLE
Fixing installation the installation error on windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "vows --spec test/*.coffee test/*.litcoffee",
     "posttest": "npm run lint",
     "prepublish": "npm run compile",
-    "install": "echo process.exit(require('fs').existsSync('lib/commandline.js') ? 0 : 1) | node || npm run compile",
+    "install": "echo 'process.exit(require(\"fs\").existsSync(\"lib/commandline.js\") ? 0 : 1)' | node || npm run compile",
     "lint": "npm run compile && ./bin/coffeelint -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee test/*.litcoffee",
     "lint-csv": "npm run compile && ./bin/coffeelint --csv -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee",
     "lint-jslint": "npm run compile && ./bin/coffeelint --jslint -f test/fixtures/coffeelint.json src/*.coffee test/*.coffee",


### PR DESCRIPTION
This should address issue #163. It has been tested on Windows 8 and Mac OS X. Essentially using javascript for the file check versus the more terse command line version.
