### PR TITLE
Missing fat arrows

### DIFF
--- a/generated_coffeelint.json
+++ b/generated_coffeelint.json
@@ -89,6 +89,10 @@
         "value": 3,
         "level": "ignore"
     },
+    "missing_fat_arrows": {
+        "name": "missing_fat_arrows",
+        "level": "ignore"
+    },
     "non_empty_constructor_needs_parens": {
         "name": "non_empty_constructor_needs_parens",
         "level": "ignore"

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -135,6 +135,7 @@ coffeelint.registerRule require './rules/duplicate_key.coffee'
 coffeelint.registerRule require './rules/empty_constructor_needs_parens.coffee'
 coffeelint.registerRule require './rules/cyclomatic_complexity.coffee'
 coffeelint.registerRule require './rules/newlines_after_classes.coffee'
+coffeelint.registerRule require './rules/missing_fat_arrows.coffee'
 coffeelint.registerRule(
     require './rules/non_empty_constructor_needs_parens.coffee'
 )

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -1,0 +1,57 @@
+isCode = (node) -> node.constructor.name is 'Code'
+isClass = (node) -> node.constructor.name is 'Class'
+isValue = (node) -> node.constructor.name is 'Value'
+isObject = (node) -> node.constructor.name is 'Obj'
+isThis = (node) -> isValue(node) and node.base.value is 'this'
+isFatArrowCode = (node) -> isCode(node) and node.bound
+
+needsFatArrow = (node) -> isCode(node) and node.body.contains(isThis)?
+
+methodsOfClass = (classNode) ->
+    bodyNodes = classNode.body.expressions
+    returnNode = bodyNodes[bodyNodes.length - 1]
+    if returnNode? and isValue(returnNode) and isObject(returnNode.base)
+        returnNode.base.properties
+            .map((assignNode) -> assignNode.value)
+            .filter(isCode)
+    else []
+
+module.exports = class MissingFatArrows
+
+    rule:
+        name: 'missing_fat_arrows'
+        level: 'ignore'
+        message: 'Used `this` in a function without a fat arrow'
+        description: """
+            Warns when you use `this` inside a function that wasn't defined
+            with a fat arrow. This rule does not apply to methods defined in a
+            class, since they have `this` bound to the class instance (or the
+            class itself, for class methods).
+
+            It is impossible to statically determine whether a function using
+            `this` will be bound with the correct `this` value due to language
+            features like `Function.prototype.call` and
+            `Function.prototype.bind`, so this rule may produce false positives.
+            """
+
+    lintAST: (node, astApi) ->
+        @lintNode node, astApi
+        undefined
+
+    lintNode: (node, astApi, methods = []) ->
+        if (not isFatArrowCode node) and
+                # Ignore any nodes we know to be methods
+                (node not in methods) and
+                (needsFatArrow node)
+            error = astApi.createError
+                lineNumber: node.locationData.first_line + 1
+            @errors.push error
+
+        node.eachChild (child) => @lintNode child, astApi,
+            switch
+                when isClass node then methodsOfClass node
+                # Once we've hit a function, we know we can't be in the top
+                # level of a method anymore, so we can safely reset the methods
+                # to empty to save work.
+                when isCode node then []
+                else methods

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -1,0 +1,112 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+{inspect} = require 'util'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+RULE = 'missing_fat_arrows'
+
+runLint = (source) ->
+    config = {}
+    config[name] = level: 'ignore' for name, rule of coffeelint.RULES
+    config[RULE].level = 'error'
+    coffeelint.lint source, config
+
+shouldError = (source, numErrors = 1) ->
+    topic: source
+    'errors for missing arrow': (source) ->
+        errors = runLint source
+        assert.lengthOf errors, numErrors,
+            "Expected #{numErrors} errors, got #{inspect errors}"
+        error = errors[0]
+        assert.equal error.rule, RULE
+
+shouldPass = (source) ->
+    topic: source
+    'does not error for no missing arrows': (source) ->
+        errors = runLint source
+        assert.isEmpty errors, "Expected no errors, got #{inspect errors}"
+
+vows.describe(RULE).addBatch({
+
+    'empty function'        : shouldPass '->'
+    'function without this' : shouldPass '-> 1'
+    'function with this'    : shouldError '-> this'
+    'function with this.a'  : shouldError '-> this.a'
+    'function with @'       : shouldError '-> @'
+    'function with @a'      : shouldError '-> @a'
+
+    'nested functions with this inside':
+        'with inner fat arrow': shouldPass '-> => this'
+        'with outer fat arrow': shouldError '=> -> this'
+        'with both fat arrows': shouldPass '=> => this'
+
+    'nested functions with this outside':
+        'with inner fat arrow': shouldError '-> (this; =>)'
+        'with outer fat arrow': shouldPass '=> (this; ->)'
+        'with both fat arrows': shouldPass '=> (this; =>)'
+
+    'deeply nested functions':
+        'with thin arrow'     : shouldError '-> -> -> -> -> this'
+        'with fat arrow'      : shouldPass '-> -> -> -> => this'
+        'with wrong fat arrow': shouldError '-> -> => -> -> this'
+
+    'functions with multiple statements' : shouldError """
+        f = ->
+            this.x = 2
+            z ((a) -> a; this.x)
+        """, 2
+
+    'class instance method':
+        'without this': shouldPass """
+            class A
+                @m: -> 1
+            """
+        'with this': shouldPass """
+            class A
+                @m: -> this
+            """
+
+    'class method':
+        'without this': shouldPass """
+            class A
+                m: -> 1
+            """
+        'with this': shouldPass """
+            class A
+                m: -> this
+            """
+
+    'function in class body':
+        'without this': shouldPass """
+            class A
+                f = -> 1
+                x: 2
+            """
+        'with this': shouldError """
+            class A
+                f = -> this
+                x: 2
+            """
+
+    'function inside class instance method':
+        'without this': shouldPass """
+            class A
+                m: -> -> 1
+            """
+        'with this': shouldError """
+            class A
+                m: -> -> @a
+            """
+
+    'mixture of class methods and function in class body':
+        'with this': shouldPass """
+            class A
+                f = => this
+                m: -> this
+                @n: -> this
+                o: -> this
+                @p: -> this
+            """
+
+}).export(module)


### PR DESCRIPTION
This rule complements no_unnecessary_fat_arrows (https://github.com/clutchski/coffeelint/pull/172). If both went in together, there is probably some common code that could be abstracted.
