### PR TITLE
Check for parameter assignment in fat arrows rules

### DIFF
--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -5,7 +5,13 @@ isObject = (node) -> node.constructor.name is 'Obj'
 isThis = (node) -> isValue(node) and node.base.value is 'this'
 isFatArrowCode = (node) -> isCode(node) and node.bound
 
-needsFatArrow = (node) -> isCode(node) and node.body.contains(isThis)?
+any = (arr, test) -> arr.reduce ((res, elt) -> res or test elt), false
+
+needsFatArrow = (node) ->
+    isCode(node) and (
+        any(node.params, (param) -> param.contains(isThis)?) or
+        node.body.contains(isThis)?
+      )
 
 methodsOfClass = (classNode) ->
     bodyNodes = classNode.body.expressions

--- a/src/rules/no_unnecessary_fat_arrows.coffee
+++ b/src/rules/no_unnecessary_fat_arrows.coffee
@@ -3,11 +3,15 @@ isFatArrowCode = (node) -> isCode(node) and node.bound
 isThis = (node) ->
     node.constructor.name is 'Value' and node.base.value is 'this'
 
+any = (arr, test) -> arr.reduce ((res, elt) -> res or test elt), false
+
 needsFatArrow = (node) ->
-    isCode(node) and
-        (node.body.contains(isThis)? or
+    isCode(node) and (
+        any(node.params, (param) -> param.contains(isThis)?) or
+        node.body.contains(isThis)? or
         node.body.contains((child) ->
-            isFatArrowCode(child) and needsFatArrow(child))?)
+            isFatArrowCode(child) and needsFatArrow(child))?
+    )
 
 module.exports = class NoUnnecessaryFatArrows
 

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -57,6 +57,10 @@ vows.describe(RULE).addBatch({
             z ((a) -> a; this.x)
         """, 2
 
+    'functions with parameters'                        : shouldPass '(a) ->'
+    'functions with parameter assignment'              : shouldError '(@a) ->'
+    'functions with destructuring parameter assignment': shouldError '({@a}) ->'
+
     'class instance method':
         'without this': shouldPass """
             class A

--- a/test/test_no_unnecessary_fat_arrows.coffee
+++ b/test/test_no_unnecessary_fat_arrows.coffee
@@ -48,10 +48,14 @@ vows.describe('no unnecessary fat arrows').addBatch({
     'deeply nested simple function'     : shouldError '-> -> -> -> => 1'
     'deeply nested function with this'  : shouldPass '-> -> -> -> => this'
 
-    'functions with multiple statements' : shouldError """
+    'functions with multiple statements': shouldError """
         f = ->
           x = 2
           z ((a) => x; a)
         """
+
+    'functions with parameters'                        : shouldError '(a) =>'
+    'functions with parameter assignment'              : shouldPass '(@a) =>'
+    'functions with destructuring parameter assignment': shouldPass '({@a}) =>'
 
 }).export(module)


### PR DESCRIPTION
I'm not sure where to put common utility functions like `any`. Also, `any` is a function that you can get from Underscore. Have you thought about making that a dependency?
