### PR TITLE
Changes onlySpaces regex to skip empty lines w/o whitespaces

### DIFF
--- a/src/rules/no_trailing_whitespace.coffee
+++ b/src/rules/no_trailing_whitespace.coffee
@@ -1,7 +1,7 @@
 
 regexes =
     trailingWhitespace : /[^\s]+[\t ]+\r?$/
-    onlySpaces: /^[\t\s]+\r?$/
+    onlySpaces: /^[\t ]+\r?$/
     lineHasComment : /^\s*[^\#]*\#/
 
 module.exports = class NoTrailingWhitespace


### PR DESCRIPTION
Right now `onlySpaces` regex matches empty lines without whitespaces because `\s` also matches carriage returns. I changed it to skip empty lines without tabs or spaces. In my opinion, there should be at least an option to allow empty lines without whitespaces.
