### PR TITLE
Add reference to coffeelint-ruby to the list of plugins

### DIFF
--- a/index-bottom.html
+++ b/index-bottom.html
@@ -172,6 +172,10 @@
                   is a plugin for
                   <a href="https://github.com/wearefractal/gulp">gulp</a>, by Jan Raasch.
               </li>
+              <li>
+                <a href="https://github.com/zipcodeman/coffeelint-ruby">coffeelint-ruby</a>
+                is a set of bindings for ruby, by Zachary Bush
+              </li>
             </ul>
           </p>
 

--- a/index.html
+++ b/index.html
@@ -639,6 +639,10 @@ is not used within the function.
                   is a plugin for
                   <a href="https://github.com/wearefractal/gulp">gulp</a>, by Jan Raasch.
               </li>
+              <li>
+                <a href="https://github.com/zipcodeman/coffeelint-ruby">coffeelint-ruby</a>
+                is a set of bindings for ruby, by Zachary Bush
+              </li>
             </ul>
           </p>
 


### PR DESCRIPTION
I hope this is not too presumptuous of me, but I've put a good amount of work trying to write some nice ruby bindings to coffeelint. 
