### PR TITLE
Lock down CS version to 1.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "optimist": ">=0.2.8",
-    "coffee-script": ">=1.6.0",
+    "coffee-script": "1.6.x",
     "glob": ">=3.1.9",
     "browserify": "~2.26.0",
     "coffeeify": "~0.5.1"


### PR DESCRIPTION
Any chance we can lock down the CoffeeScript version? Or at least have a separate npm version for a locked down version to 1.6.x?

We're not ready to move to CS 1.7 yet - and there are some breaking changes preventing us from doing so - but coffeelint will automatically install 1.7 anyway, and there's no option to stop this.

AFAICT coffeelint works with 1.7 - but without a separate npm version/branch there's no way to specify it to use 1.6
