### PR TITLE
Fixes #194 no_trailing_semicolons problem

### DIFF
--- a/test/test_semicolons.coffee
+++ b/test/test_semicolons.coffee
@@ -3,6 +3,8 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
+configError = {no_trailing_semicolons : {level : 'error'}}
+configIgnore = {no_trailing_semicolons : {level : 'ignore'}}
 
 vows.describe('semicolons').addBatch({
 
@@ -23,9 +25,7 @@ vows.describe('semicolons').addBatch({
             assert.equal(error.rule, 'no_trailing_semicolons')
 
         'can be ignored' : (source) ->
-            config =
-                no_trailing_semicolons : {level: 'ignore'}
-            errors = coffeelint.lint(source, config)
+            errors = coffeelint.lint(source, configIgnore)
             assert.isEmpty(errors)
 
     'Semicolons in multiline expressions' :
@@ -49,10 +49,51 @@ vows.describe('semicolons').addBatch({
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
-    "Trailing Semicolons in comments":
-        topic: "undefined\n# comment;\nundefined"
-        "are ignored": (source) ->
+    'Trailing semicolon in comments' :
+        topic : "undefined\n# comment;\nundefined"
+
+        'are ignored' : (source) ->
             errors = coffeelint.lint(source, {})
+            assert.isEmpty(errors)
+
+    'Trailing semicolon in comments with no semicolon in statement':
+
+        topic : "x = 3 #set x to 3;"
+
+        'are ignored' : (source) ->
+            errors = coffeelint.lint(source, configIgnore)
+            assert.isEmpty(errors)
+
+        'will throw an error' : (source) ->
+            errors = coffeelint.lint(source, configError)
+            assert.isEmpty(errors)
+
+    'Trailing semicolon in comments with semicolon in statement':
+
+        topic : "x = 3; #set x to 3;"
+
+        'are ignored' : (source) ->
+            errors = coffeelint.lint(source, configIgnore)
+            assert.isEmpty(errors)
+
+        'will throw an error' : (source) ->
+            errors = coffeelint.lint(source, configError)
+            assert.lengthOf(errors, 1)
+            error = errors[0]
+            assert.equal(error.lineNumber, 1)
+            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.rule, 'no_trailing_semicolons')
+
+    'Trailing semicolon in block comments' :
+
+        topic : "###\nThis is a block comment;\n###"
+
+        'are ignored' : (source) ->
+            errors = coffeelint.lint(source, configIgnore)
+            assert.isEmpty(errors)
+
+        'are ignored even if config level is error' : (source) ->
+            errors = coffeelint.lint(source, configError)
             assert.isEmpty(errors)
 
     'Semicolons with windows line endings' :


### PR DESCRIPTION
This commit fixes the problem where if no_trailing_semicolons is
enabled, a semicolon at the end of a comment would trigger this rule.

This fixes the problem by chopping off comments before triggering
the rule.

---

Note also that the block comments actually tokenize into one token that surrounds the text inside of the block with newlines, so it will probably be unlikely that they will ever trigger this rule. However I have told the rule to skip those tokens, and also added a test in case something change in the future
