### PR TITLE
Add a failing test showing a valid chained call that fails.

### DIFF
--- a/test/test_indent.coffee
+++ b/test/test_indent.coffee
@@ -208,4 +208,19 @@ vows.describe('indent').addBatch({
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
+    'Indenting callbacks to multiple chained calls' :
+
+        topic: """
+            anArray
+              .filter (item) ->
+                item.status in ACTIVE_STATUSES
+              .map (item) ->
+                item.service
+            """
+
+        'is permitted' : (source) ->
+            errors = coffeelint.lint(source)
+            assert.isEmpty(errors)
+
+
 }).export(module)


### PR DESCRIPTION
I tried to fix this for a little while and eventually gave up. This case makes me feel like the indent rule should be linting the AST, not the tokens. Given this CS:

``` coffee
anArray
  .filter (item) ->
    item.status in ACTIVE_STATUSES
  .map (item) ->
    item.service
```

Which turns into this JS:

``` js
anArray.filter(function(item) {
  var _ref;
  return _ref = item.status, __indexOf.call(ACTIVE_STATUSES, _ref) >= 0;
}).map(function(item) {
  return item.service;
});
```

I get this failure that should not happen:

```
  Indenting callbacks to multiple chained calls
    ✗ is permitted
        » expected [
      {
          name: 'indentation',
          value: 2,
          level: 'error',
          message: 'Line contains inconsistent indentation',
          description: "This rule imposes a standard number of spaces to be used for\nindentation. Since whitespace is significant in CoffeeScript, it's\ncritical that a project chooses a standard indentation format and\nstays consistent. Other roads lead to darkness. <pre> <code>#\nEnabling this option will prevent this ugly\n# but otherwise valid CoffeeScript.\ntwoSpaces = () ->\n  fourSpaces = () ->\n      eightSpaces = () ->\n            'this is valid CoffeeScript'\n\n</code>\n</pre>\nTwo space indentation is enabled by default.",
          context: 'Expected 2 got 4',
          lineNumber: 5,
          line: '    item.service',
          rule: 'indentation'
      }
  ] to be empty // test_indent.coffee:223
```

It seems like we'd have to incorporate some of the smarts in the CS compiler itself to determine this is a chained call. How do you think we should handle this?
