### PR TITLE
fix env error while invoked by Sublime Text 3's plugin "Better Coffeescript"

### DIFF
--- a/src/configfinder.coffee
+++ b/src/configfinder.coffee
@@ -47,7 +47,8 @@ exports.getConfig = (filename = null) ->
         return npmConfig  if npmConfig
         projConfig = findFile("coffeelint.json", dir)
         return loadJSON(projConfig)  if projConfig
-    envs = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
+    envs = process.env.HOME or process.env.HOMEPATH or
+        process.env.USERPROFILE or ''
     home = path.normalize(path.join(envs, "coffeelint.json"))
     if fs.existsSync(home)
         console.log 'loaded', home


### PR DESCRIPTION
Invoked by Sublime Text 3, the following code will return as value of  `undefined` 

```
envs = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
```

It will cause path's error as following:

```
TypeError: Arguments to path.join must be strings
  at path.js:360:15
  at Array.filter (native)
  at Object.exports.join (path.js:358:36)
  at Object.exports.getConfig (/usr/local/lib/node_modules/coffeelint/lib/configfinder.js:69:32)
  at getFallbackConfig (/usr/local/lib/node_modules/coffeelint/lib/commandline.js:384:27)
  at lintFiles (/usr/local/lib/node_modules/coffeelint/lib/commandline.js:350:38)
  at Object.<anonymous> (/usr/local/lib/node_modules/coffeelint/lib/commandline.js:471:21)
  at Object.<anonymous> (/usr/local/lib/node_modules/coffeelint/lib/commandline.js:476:4)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/usr/local/lib/node_modules/coffeelint/bin/coffeelint:17:5)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:902:3
```
