### PR TITLE
Add no_empty_functions rule that triggers if an empty function is defined

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -147,6 +147,7 @@ coffeelint.registerRule require './rules/no_debugger.coffee'
 coffeelint.registerRule(
     require './rules/no_interpolation_in_single_quotes.coffee'
 )
+coffeelint.registerRule require './rules/no_empty_functions.coffee'
 
 hasSyntaxError = (source) ->
     try

--- a/src/rules/no_empty_functions.coffee
+++ b/src/rules/no_empty_functions.coffee
@@ -1,0 +1,24 @@
+isEmptyCode = (node, astApi) ->
+    nodeName = astApi.getNodeName node
+    nodeName is 'Code' and node.body.isEmpty()
+
+module.exports = class NoEmptyFunctions
+
+    rule:
+        name: 'no_empty_functions'
+        level: 'ignore'
+        message: 'Empty function'
+        description: """
+            Disallows declaring empty functions.
+            """
+
+    lintAST: (node, astApi) ->
+        @lintNode node, astApi
+        undefined
+
+    lintNode: (node, astApi) ->
+        if isEmptyCode node, astApi
+            error = astApi.createError
+                lineNumber: node.locationData.first_line + 1
+            @errors.push error
+        node.eachChild (child) => @lintNode child, astApi

--- a/test/test_no_empty_functions.coffee
+++ b/test/test_no_empty_functions.coffee
@@ -1,0 +1,46 @@
+path        = require 'path'
+vows        = require 'vows'
+assert      = require 'assert'
+coffeelint  = require path.join('..', 'lib', 'coffeelint')
+
+runLint = (source) ->
+    config = no_empty_functions: level: 'error'
+    coffeelint.lint source, config
+
+shouldError = (source, numErrors = 1, errorNames = ['no_empty_functions']) ->
+    topic: source
+    'errors for empty function': (source) ->
+        errors = runLint source
+        assert.lengthOf errors, numErrors, "Expected #{numErrors} errors, got
+            [#{errors.map( (error) -> error.name).join ', '}] instead"
+        for errorName in errorNames
+            assert.notEqual errors.indexOf errorName, -1
+
+shouldPass = (source) ->
+    topic: source
+    'does not error for empty function': (source) ->
+        errors = runLint source
+        assert.isEmpty errors, "Expected no errors, got
+            [#{errors.map( (error) -> error.name).join ', '}] instead"
+
+vows.describe('no empty functions').addBatch({
+    'empty fat-arrow function'                          : shouldError(
+        '=>', 2)
+    'empty function'                                    : shouldError(
+        '->')
+    'function with undefined statement'                 : shouldPass(
+        '-> undefined')
+    'function within function with undefined statement' : shouldPass(
+        '-> -> undefined')
+    'empty fat arrow function within a function '       : shouldError(
+        '-> =>', 2)
+    'empty function within a function '                 : shouldError(
+        '-> ->')
+    "empty function as param's default value"           : shouldError(
+        'foo = (empty=(->)) -> undefined')
+    "non-empty function as param's default value"       : shouldPass(
+        'foo = (empty=(-> undefined)) -> undefined')
+    "empty function with implicit instance member
+    assignment as param"                                : shouldError(
+        'foo = (@_fooMember) ->')
+}).export(module)


### PR DESCRIPTION
In the past, I have been bitten by the following code:

```
someFunctionWithCallback ->
doSomethingSignificant()
```

What's wrong is that _doSomethingSignificant_ is called no matter what after the call to _someFunctionWithCallback_, whereas what I really wanted to do is to call _doSomethingSignificant_ from within the callback. It makes a big difference whether _someFunctionWithCallback_ is asynchronous or not.

These kind of issues can sometimes be very tricky to find. This error is often located deep into the source code and when you look at it, it's hard to spot that an indentation token is missing. Moreover, the execution of such code may look perfectly valid, since you expected _doSomethingSignificant_ to be called anyway.

The _no_empty_functions_ rule triggers an error on such code. 

I have never used empty functions myself, but I know that other programmers like to do so. When one wants to define an empty function, one only has to use _undefined_ as the only expression within the function body, like so:

```
someFunction ->
  undefined
```

It states the intention clearly, and it's not too long to type. It's even similar to Python's pass statement.
