### PR TITLE
Fix MissingFatArrows, NoUnnecessaryFatArrows, and CyclomaticComplexity

### DIFF
--- a/generated_coffeelint.json
+++ b/generated_coffeelint.json
@@ -67,6 +67,7 @@
     },
     "no_implicit_parens": {
         "name": "no_implicit_parens",
+        "strict": true,
         "level": "ignore"
     },
     "no_empty_param_list": {
@@ -113,6 +114,14 @@
     },
     "no_unnecessary_double_quotes": {
         "name": "no_unnecessary_double_quotes",
+        "level": "ignore"
+    },
+    "no_debugger": {
+        "name": "no_debugger",
+        "level": "warn"
+    },
+    "no_interpolation_in_single_quotes": {
+        "name": "no_interpolation_in_single_quotes",
         "level": "ignore"
     }
 }

--- a/src/ast_linter.coffee
+++ b/src/ast_linter.coffee
@@ -1,7 +1,32 @@
 BaseLinter = require './base_linter.coffee'
 
+node_children =
+  Class:    ['variable', 'parent', 'body']
+  Code:     ['params', 'body']
+  For:      ['body', 'source', 'guard', 'step']
+  If:       ['condition', 'body', 'elseBody']
+  Obj:      ['properties']
+  Op:       ['first', 'second']
+  Switch:   ['subject', 'cases', 'otherwise']
+  Try:      ['attempt', 'recovery', 'ensure']
+  Value:    ['base', 'properties']
+  While:    ['condition', 'guard', 'body']
+
+hasChildren = (node, children) ->
+    node?.children?.length is children.length and
+    node?.children.every (elem, i) -> elem is children[i]
+
 class ASTApi
     constructor: (@config) ->
+    getNodeName: (node) ->
+        name = node?.constructor?.name
+        if node_children[name]
+            return name
+        else
+            for own name, children of node_children
+                if hasChildren(node, children)
+                    return name
+
 
 # A class that performs static analysis of the abstract
 # syntax tree.

--- a/src/rules/cyclomatic_complexity.coffee
+++ b/src/rules/cyclomatic_complexity.coffee
@@ -9,7 +9,7 @@ module.exports = class NoTabs
 
     # returns the "complexity" value of the current node.
     getComplexity : (node) ->
-        name = node.constructor.name
+        name = @astApi.getNodeName node
         complexity = if name in ['If', 'While', 'For', 'Try']
             1
         else if name == 'Op' and node.operator in ['&&', '||']
@@ -28,7 +28,7 @@ module.exports = class NoTabs
     lintNode : (node, line) ->
 
         # Get the complexity of the current node.
-        name = node.constructor.name
+        name = @astApi?.getNodeName node
         complexity = @getComplexity(node)
 
         # Add the complexity of all child's nodes to this one.

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -1,26 +1,4 @@
-isCode = (node) -> node?.constructor.name is 'Code'
-isClass = (node) -> node.constructor.name is 'Class'
-isValue = (node) -> node.constructor.name is 'Value'
-isObject = (node) -> node.constructor.name is 'Obj'
-isThis = (node) -> isValue(node) and node.base.value is 'this'
-isFatArrowCode = (node) -> isCode(node) and node.bound
-
 any = (arr, test) -> arr.reduce ((res, elt) -> res or test elt), false
-
-needsFatArrow = (node) ->
-    isCode(node) and (
-        any(node.params, (param) -> param.contains(isThis)?) or
-        node.body.contains(isThis)?
-      )
-
-methodsOfClass = (classNode) ->
-    bodyNodes = classNode.body.expressions
-    returnNode = bodyNodes[bodyNodes.length - 1]
-    if returnNode? and isValue(returnNode) and isObject(returnNode.base)
-        returnNode.base.properties
-            .map((assignNode) -> assignNode.value)
-            .filter(isCode)
-    else []
 
 module.exports = class MissingFatArrows
 
@@ -40,24 +18,47 @@ module.exports = class MissingFatArrows
             `Function.prototype.bind`, so this rule may produce false positives.
             """
 
-    lintAST: (node, astApi) ->
-        @lintNode node, astApi
+    lintAST: (node, @astApi) ->
+        @lintNode node
         undefined
 
-    lintNode: (node, astApi, methods = []) ->
-        if (not isFatArrowCode node) and
+    lintNode: (node, methods = []) ->
+        if (not @isFatArrowCode node) and
                 # Ignore any nodes we know to be methods
                 (node not in methods) and
-                (needsFatArrow node)
-            error = astApi.createError
+                (@needsFatArrow node)
+            error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1
             @errors.push error
 
-        node.eachChild (child) => @lintNode child, astApi,
+        node.eachChild (child) => @lintNode child,
             switch
-                when isClass node then methodsOfClass node
+                when @isClass node then @methodsOfClass node
                 # Once we've hit a function, we know we can't be in the top
                 # level of a method anymore, so we can safely reset the methods
                 # to empty to save work.
-                when isCode node then []
+                when @isCode node then []
                 else methods
+
+    isCode: (node) => @astApi.getNodeName(node) is 'Code'
+    isClass: (node) => @astApi.getNodeName(node) is 'Class'
+    isValue: (node) => @astApi.getNodeName(node) is 'Value'
+    isObject: (node) => @astApi.getNodeName(node) is 'Obj'
+    isThis: (node) => @isValue(node) and node.base.value is 'this'
+    isFatArrowCode: (node) => @isCode(node) and node.bound
+
+    needsFatArrow: (node) ->
+        @isCode(node) and (
+            any(node.params, (param) => param.contains(@isThis)?) or
+            node.body.contains(@isThis)?
+          )
+
+    methodsOfClass: (classNode) ->
+        bodyNodes = classNode.body.expressions
+        returnNode = bodyNodes[bodyNodes.length - 1]
+        if returnNode? and @isValue(returnNode) and @isObject(returnNode.base)
+            returnNode.base.properties
+                .map((assignNode) -> assignNode.value)
+                .filter(@isCode)
+        else []
+


### PR DESCRIPTION
In the browser, the node.constructor.name values get minified, and become useless

Instead check the value of the children of the node

This is to fix https://github.com/zmbush/coffeelint-ruby/issues/10
