### PR TITLE
Add fix for line length detection under Windows

### DIFF
--- a/src/rules/max_line_length.coffee
+++ b/src/rules/max_line_length.coffee
@@ -31,7 +31,7 @@ module.exports = class MaxLineLength
         max = lineApi.config[@rule.name]?.value
         limitComments = lineApi.config[@rule.name]?.limitComments
 
-        lineLength = line.length
+        lineLength = line.trim().length
         if lineApi.isLiterate() and regexes.literateComment.test(line)
             lineLength -= 2
 

--- a/test/test_line_length.coffee
+++ b/test/test_line_length.coffee
@@ -48,6 +48,12 @@ vows.describe('linelength').addBatch({
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
+        'respects Windows line breaks': ->
+            source = new Array(81).join('X') + "\r\n"
+
+            errors = coffeelint.lint(source, {})
+            assert.isEmpty(errors)
+
     'Literate Line Length' :
         topic: ->
             # This creates a line with 80 Xs.


### PR DESCRIPTION
Hey there. The line length rule is currently overly harsh under Windows, where it rejects lines of 80 characters due to the `\r` in `\r\n` being counted as an 81st character.

This patch provides a test case illustrating the problem as well as a simple fix which also plays nice with the line ending rule.

Caveat: Didn’t test it under Windows myself, only ran the test suite.
