### PR TITLE
JSON schema for coffeelint.json

### DIFF
--- a/src/coffeelint-schema.json
+++ b/src/coffeelint-schema.json
@@ -1,0 +1,314 @@
+{
+  "title": "JSON schema for coffeelint.json files",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "level": {
+      "description": "Determines the error level",
+      "type": "string",
+      "enum": [ "warn", "error", "ignore" ]
+    },
+    "coffeelint": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "arrow_spacing": {
+          "description": "This rule checks to see that there is spacing before and after the arrow operator that declares a function.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "camel_case_classes": {
+          "description": "This rule mandates that all class names are CamelCased. Camel casing class names is a generally accepted way of distinguishing constructor functions - which require the 'new' prefix to behave properly - from plain old functions.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "coffeescript_error": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "colon_assignment_spacing": {
+          "description": "This rule checks to see that there is spacing before and after the colon in a colon assignment (i.e., classes, objects).",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "spacing": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "integer",
+                  "enum": [0, 1]
+                },
+                "right": {
+                  "type": "integer",
+                  "enum": [0, 1]
+                }
+              }
+            }
+          }
+        },
+        "cyclomatic_complexity": {
+          "description": "Examine the complexity of your application.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "value": {
+              "type": "integer"
+            }
+          }
+        },
+        "duplicate_key": {
+          "description": "Prevents defining duplicate keys in object literals and classes.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "empty_constructor_needs_parens": {
+          "description": "Requires constructors with no parameters to include the parens.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "indentation": {
+          "description": " This rule imposes a standard number of spaces to be used for indentation. Since whitespace is significant in CoffeeScript, it's critical that a project chooses a standard indentation format and stays consistent. Other roads lead to darkness.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "value": {
+              "type": "integer",
+              "enum": [2, 4]
+            }
+          }
+        },
+        "line_endings": {
+          "description": "This rule ensures your project uses only windows or unix line endings.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "value": {
+              "type": "string",
+              "enum": [ "unix", "windows" ]
+            }
+          }
+        },
+        "max_line_length": {
+          "description": "This rule imposes a maximum line length on your code.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "value": {
+              "type": "integer"
+            },
+            "limitComments": {
+              "type": "boolean"
+            }
+          }
+        },
+        "missing_fat_arrows": {
+          "description": "Warns when you use `this` inside a function that wasn't defined with a fat arrow. This rule does not apply to methods defined in a class, since they have `this` bound to the class instance (or the class itself, for class methods).",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "newlines_after_classes": {
+          "description": "Checks the number of newlines between classes and other code.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "value": {
+              "type": "integer",
+              "enum": [0, 1, 2]
+            }
+          }
+        },
+        "no_backticks": {
+          "description": "Backticks allow snippets of JavaScript to be embedded in CoffeeScript. While some folks consider backticks useful in a few niche circumstances, they should be avoided because so none of JavaScript's \"bad parts\", like with and eval, sneak into CoffeeScript.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_debugger": {
+          "description": "This rule detects the `debugger` statement.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_empty_param_list": {
+          "description": "This rule prohibits empty parameter lists in function definitions.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_implicit_braces": {
+          "description": "This rule prohibits implicit braces when declaring object literals. Implicit braces can make code more difficult to understand, especially when used in combination with optional parenthesis.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "strict": {
+              "type": "boolean"
+            }
+          }
+        },
+        "no_implicit_parens": {
+          "description": "This rule prohibits implicit parens on function calls.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_interpolation_in_single_quotes": {
+          "description": "This rule prohibits string interpolation in a single quoted string.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_plusplus": {
+          "description": "This rule forbids the increment and decrement arithmetic operators. Some people believe the ++ and -- to be cryptic and the cause of bugs due to misunderstandings of their precedence rules.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_stand_alone_at": {
+          "description": "This rule checks that no stand alone @ are in use, they are discouraged.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_tabs": {
+          "description": "This rule forbids tabs in indentation. Enough said.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_throwing_strings": {
+          "description": " This rule forbids throwing string literals or interpolations. While JavaScript (and CoffeeScript by extension) allow any expression to be thrown, it is best to only throw  Error objects, because they contain valuable debugging information like the stack trace.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_trailing_semicolons": {
+          "description": "This rule prohibits trailing semicolons, since they are needless cruft in CoffeeScript.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_trailing_whitespace": {
+          "description": "This rule forbids trailing whitespace in your code, since it is needless cruft.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "allowed_in_comments": {
+              "type": "boolean"
+            },
+            "allowed_in_empty_lines": {
+              "type": "boolean"
+            }
+          }
+        },
+        "no_unnecessary_double_quotes": {
+          "description": "This rule prohibits double quotes unless string interpolation is used or the string contains single quotes.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "no_unnecessary_fat_arrows": {
+          "description": "Disallows defining functions with fat arrows when `this` is not used within the function. ",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "non_empty_constructor_needs_parens": {
+          "description": "Requires constructors with parameters to include the parens.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        },
+        "space_operators": {
+          "description": "This rule enforces that operators have space around them. ",
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "oneOf": [ { "$ref": "#/definitions/coffeelint" } ],
+  "type": "object"
+}


### PR DESCRIPTION
Any editor/IDE supporting json-schema will be able to provide rich auto-completion for `coffeelint.json` files.

![completion](https://cloud.githubusercontent.com/assets/1258877/2715041/d4de18f0-c502-11e3-8737-d0dd90ecaa4e.png)

This makes it much easier to work with `coffeelint.json` files as well as helping to avoid typos. In addition, tooltips can be provided for easy explanations to each property.

![completion2](https://cloud.githubusercontent.com/assets/1258877/2715048/20c371d4-c503-11e3-8ccf-4e709a80dd97.png)

A json-schema file can also be used as documentation for the `coffeelint.json` file.
