### PR TITLE
Document no_empty_functions rule more thoroughly.

### DIFF
--- a/src/rules/no_empty_functions.coffee
+++ b/src/rules/no_empty_functions.coffee
@@ -9,7 +9,28 @@ module.exports = class NoEmptyFunctions
         level: 'ignore'
         message: 'Empty function'
         description: """
-            Disallows declaring empty functions.
+            Disallows declaring empty functions. The goal of this rule is that
+            unintentional empty callbacks can be detected:
+            <pre>
+            <code>someFunctionWithCallback ->
+            doSomethingSignificant()
+            </code>
+            </pre>
+            The problem is that the call to
+            <tt>doSomethingSignificant</tt> will be made regardless
+            of <tt>someFunctionWithCallback</tt>'s execution. It can
+            be because you did not indent the call to
+            <tt>doSomethingSignificant</tt> properly.
+
+            If you really meant that <tt>someFunctionWithCallback</tt>
+            should call a callback that does nothing, you can write your code
+            this way:
+            <pre>
+            <code>someFunctionWithCallback ->
+                undefined
+            doSomethingSignificant()
+            </code>
+            </pre>
             """
 
     lintAST: (node, astApi) ->


### PR DESCRIPTION
Documentation generation has been tested with the gh-pages branch according to instructions mentioned in PR #254. `npm test` has also been run just to make sure that formatting hasn't been broken in the process (long lines, etc.).
