### PR TITLE
fix: resolve package dependecy version was mistyped

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffeeify": "~0.6.0",
     "glob": ">=3.1.9",
     "optimist": ">=0.2.8",
-    "resolve": "^0.6.3"
+    "resolve": "~0.6.3"
   },
   "devDependencies": {
     "vows": ">=0.6.0",


### PR DESCRIPTION
npm instal did not work for me because of resolve's version modifier, this fixed for me.
