### PR TITLE
Fixes #271 Trailing semicolon check

### DIFF
--- a/src/rules/no_trailing_semicolons.coffee
+++ b/src/rules/no_trailing_semicolons.coffee
@@ -51,9 +51,8 @@ module.exports = class NoTrailingSemicolons
         hasSemicolon = regexes.trailingSemicolon.test(newLine)
         [first..., last] = lineTokens
         hasNewLine = last and last.newLine?
-
         # Don't throw errors when the contents of  multiline strings,
         # regexes and the like end in ";"
         if hasSemicolon and not hasNewLine and lineApi.lineHasToken() and
-                last[0] isnt 'STRING'
+                not (last[0] in ['STRING', 'IDENTIFIER'])
             return true

--- a/test/test_semicolons.coffee
+++ b/test/test_semicolons.coffee
@@ -34,10 +34,16 @@ vows.describe('semicolons').addBatch({
             x = "asdf;
             asdf"
 
-            y = """
+            y1 = """
             #{asdf1};
             _#{asdf2}_;
             asdf;
+            """
+
+            y2 = """
+                #{asdf1};
+                _#{asdf2}_;
+                asdf;
             """
 
             z = ///


### PR DESCRIPTION
Patch to handle when CoffeeScript's lexer spits out an identifier as the
last token in a line with a semicolon, rather than a string token.
