### PR TITLE
`makeconfig` writes json sorted by rule name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "coffeeify": "~0.6.0",
     "glob": "^4.0.0",
     "optimist": "^0.6.1",
-    "resolve": "^0.6.3"
+    "resolve": "^0.6.3",
+    "sorted-object": "^1.0.0"
   },
   "devDependencies": {
     "vows": ">=0.6.0",

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -12,6 +12,7 @@ fs   = require("fs")
 os   = require("os")
 glob = require("glob")
 optimist = require("optimist")
+sortedObject = require("sorted-object")
 thisdir = path.dirname(fs.realpathSync(__filename))
 coffeelint = require(path.join(thisdir, "coffeelint"))
 configfinder = require(path.join(thisdir, "configfinder"))
@@ -248,7 +249,7 @@ else if options.argv.h
     options.showHelp()
     process.exit(0)
 else if options.argv.makeconfig
-    console.log JSON.stringify coffeelint.RULES,
+    console.log JSON.stringify sortedObject(coffeelint.RULES),
         ((k,v) -> v unless k in ['message', 'description']), 4
 else if options.argv._.length < 1 and not options.argv.s
     options.showHelp()


### PR DESCRIPTION
When using the cli `--makeconfig` option, the JSON is not written in alphabetical order, which can be very annoying when looking up each option on http://www.coffeelint.org/. This sorts the rules before writing them to stdout.
