### PR TITLE
Autoload rules from config Fixes grunt-coffeelint#51

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -23,10 +23,11 @@ task 'compile:commandline', 'Compiles commandline.js', ->
     coffeeSync 'src/commandline.coffee', 'lib/commandline.js'
     coffeeSync 'src/configfinder.coffee', 'lib/configfinder.js'
     coffeeSync 'src/cache.coffee', 'lib/cache.js'
+    coffeeSync 'src/ruleLoader.coffee', 'lib/ruleLoader.js'
     fs.mkdirSync 'lib/reporters' unless fs.existsSync 'lib/reporters'
     for src in glob.sync('reporters/*.coffee', { cwd: 'src' })
         # Slice the "coffee" extension of the end and replace with js
-        dest = src[...-6]+'js'
+        dest = src[...-6] + 'js'
         coffeeSync "src/#{src}", "lib/#{dest}"
 
 task 'compile:browserify', 'Uses browserify to compile coffeelint', ->

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -11,17 +11,19 @@ CoffeeLint is freely distributable under the MIT license.
 # exports
 coffeelint = exports
 
+# Hide from browserify
+nodeRequire = require
+
 if window?
     # If we're in the browser assume CoffeeScript is already loaded.
     CoffeeScript = window.CoffeeScript
 else
-    # By storing this in a variable it prevents browserify from finding this
-    # dependency. If it isn't hidden there is an error attempting to inline
-    # CoffeeScript.  if browserify uses `-i` to ignore the dependency it
-    # creates an empty shim which breaks NodeJS
+    # By using nodeRequire it prevents browserify from finding this dependency.
+    # If it isn't hidden there is an error attempting to inline CoffeeScript.
+    # if browserify uses `-i` to ignore the dependency it creates an empty shim
+    # which breaks NodeJS
     # https://github.com/substack/node-browserify/issues/471
-    cs = 'coffee-script'
-    CoffeeScript = require cs
+    CoffeeScript = nodeRequire 'coffee-script'
 
 # Browserify will inline the file at compile time.
 packageJSON = require('./../package.json')
@@ -180,6 +182,11 @@ hasSyntaxError = (source) ->
 #   }
 #
 coffeelint.lint = (source, userConfig = {}, literate = false) ->
+
+    # When run from the browser it may not be able to find the ruleLoader.
+    try
+        ruleLoader = nodeRequire './ruleLoader'
+        ruleLoader.loadFromConfig this, userConfig
 
     cache?.setConfig userConfig
     if cache?.has source then return cache?.get source

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -15,10 +15,10 @@ optimist = require("optimist")
 thisdir = path.dirname(fs.realpathSync(__filename))
 coffeelint = require(path.join(thisdir, "coffeelint"))
 configfinder = require(path.join(thisdir, "configfinder"))
+ruleLoader = require(path.join(thisdir, 'ruleLoader'))
 Cache = require(path.join(thisdir, "cache"))
 CoffeeScript = require 'coffee-script'
 CoffeeScript.register()
-
 
 # Return the contents of the given file synchronously.
 read = (path) ->
@@ -86,10 +86,6 @@ lintFiles = (files, config) ->
 
         fileConfig = if config then config else getFallbackConfig(file)
 
-        for ruleName, data of fileConfig
-            if data.module?
-                loadRules(data.module, ruleName)
-
         errorReport.paths[file] = coffeelint.lint(source, fileConfig, literate)
     return errorReport
 
@@ -97,10 +93,6 @@ lintFiles = (files, config) ->
 lintSource = (source, config, literate = false) ->
     errorReport = new ErrorReport()
     config or= getFallbackConfig()
-
-    for ruleName, data of config
-        if data.module?
-            loadRules(data.module, ruleName)
 
     errorReport.paths["stdin"] = coffeelint.lint(source, config, literate)
     return errorReport
@@ -268,7 +260,7 @@ else
         fs.existsSync(process.env.COFFEELINT_CONFIG))
             config = JSON.parse(read(process.env.COFFEELINT_CONFIG))
 
-    loadRules(options.argv.rules) if options.argv.rules
+    ruleLoader.loadRule(coffeelint, options.argv.rules) if options.argv.rules
 
     if options.argv.s
         # Lint from stdin

--- a/src/ruleLoader.coffee
+++ b/src/ruleLoader.coffee
@@ -1,0 +1,44 @@
+path = require 'path'
+resolve = require('resolve').sync
+
+# moduleName is a NodeJS module, or a path to a module NodeJS can load.
+module.exports =
+
+    loadFromConfig: (coffeelint, config) ->
+        for ruleName, data of config when data?.module?
+            @loadRule(coffeelint, data.module, ruleName)
+
+    # moduleName is a NodeJS module, or a path to a module NodeJS can load.
+    loadRule: (coffeelint, moduleName, ruleName = undefined) ->
+        try
+            try
+                # Try to find the project-level rule first.
+                rulePath = resolve moduleName, {
+                    basedir: process.cwd()
+                }
+                ruleModule = require rulePath
+            try
+                # This seems awkward, but the ?= will prevent it from trying to
+                # require if the previous step succeeded without an exception.
+                #
+                # Globally installed rule
+                ruleModule ?= require moduleName
+
+            # Maybe the user used a relative path from the command line. This
+            # doesn't make much sense from a config file, but seems natural
+            # with the --rules option.
+            #
+            # No try around this one, an exception here should abort the rest of
+            # this function.
+            ruleModule ?= require path.resolve(process.cwd(), moduleName)
+
+            # Most rules can export as a single constructor function
+            if typeof ruleModule is 'function'
+                coffeelint.registerRule ruleModule, ruleName
+            else
+                # Or it can export an array of rules to load.
+                for rule in ruleModule
+                    coffeelint.registerRule rule
+        catch e
+            console.error "Error loading #{moduleName}"
+            throw e


### PR DESCRIPTION
I created a gist that can be checked out and run to demonstrate the issue this solves.

https://gist.github.com/AsaAyers/140023f09a10c2d0a149

Without this change in place `coffeelint Gruntfile.coffee` will report the missing `use strict` and `grunt` will report all is fine. The correct output should look like this

```
➜  140023f09a10c2d0a149 git:(master) ✗ npm test

> gcl-test@0.0.0 test /tmp/140023f09a10c2d0a149
> coffeelint Gruntfile.coffee; grunt

resolve /tmp/140023f09a10c2d0a149
  ✗ Gruntfile.coffee
     ✗ #4: Missing 'use strict' statement.

✗ Lint! » 1 error and 0 warnings in 1 file

Running "coffeelint:tests" (coffeelint) task
resolve /tmp/140023f09a10c2d0a149

Gruntfile.coffee
  ✖  line 4  Missing 'use strict' statement

✖ 1 error

Warning: Task "coffeelint:tests" failed. Use --force to continue.

Aborted due to warnings.
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
