### PR TITLE
rerun for #251 (fix for fat arrow positives

### DIFF
--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -1,5 +1,15 @@
 any = (arr, test) -> arr.reduce ((res, elt) -> res or test elt), false
 
+containsButIsnt = (node, nIsThis, nIsClass) ->
+    target = undefined
+    node.traverseChildren false, (n) ->
+        if nIsClass n
+            return false
+        if nIsThis n
+            target = n
+            return false
+    target
+
 module.exports = class MissingFatArrows
 
     rule:
@@ -47,10 +57,13 @@ module.exports = class MissingFatArrows
     isThis: (node) => @isValue(node) and node.base.value is 'this'
     isFatArrowCode: (node) => @isCode(node) and node.bound
 
+
+
+
     needsFatArrow: (node) ->
         @isCode(node) and (
             any(node.params, (param) => param.contains(@isThis)?) or
-            node.body.contains(@isThis)?
+            containsButIsnt(node.body, @isThis, @isClass)
           )
 
     methodsOfClass: (classNode) ->

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -122,5 +122,15 @@ vows.describe(RULE).addBatch({
                 ###
                 doNothing: () ->
         """
-
+    'function ouside class instance method':
+        'without this': shouldPass """
+            ->
+                class A
+                    m: ->
+                """
+        'with this': shouldPass """
+            ->
+                class A
+                    @m: ->
+                """
 }).export(module)


### PR DESCRIPTION
I also encountered issue #249. @Sinetheta fix works fine for me. Here's a hopefully working pull request.
(only for the missinng_fat_arrow_rule)

As `containsButIsnt` aborts as soon as it finds a class node, I am not sure whether this really covers all special cases. However all tests run fine.
