### PR TITLE
Add array_initialization rule

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -128,6 +128,7 @@ coffeelint.getRules = ->
     output
 
 # These all need to be explicitly listed so they get picked up by browserify.
+coffeelint.registerRule require './rules/array_initialization.coffee'
 coffeelint.registerRule require './rules/arrow_spacing.coffee'
 coffeelint.registerRule require './rules/no_tabs.coffee'
 coffeelint.registerRule require './rules/no_trailing_whitespace.coffee'

--- a/src/rules/array_initialization.coffee
+++ b/src/rules/array_initialization.coffee
@@ -1,0 +1,29 @@
+isArrayInitializationUsingConstructor = (node, astApi) ->
+    astApi.getNodeName(node?.value) is 'Op' and
+        node.value.operator is 'new' and
+        astApi.getNodeName(node.value.first) is 'Value' and
+        node.value.first.base?.value is 'Array'
+
+module.exports = class ArrayInitialization
+
+    rule:
+        name: 'array_initialization'
+        level: 'ignore'
+        message: 'Array initialization using the Array constructor is forbidden'
+        description: """
+            This rule forbids the use of the Array constructor for initializing
+            arrays.
+            Some insist on always using `[]` for initializing arrays.
+            This rule is disabled by default.
+            """
+
+    lintAST: (node, astApi) ->
+        @lintNode node, astApi
+        undefined
+
+    lintNode: (node, astApi) ->
+        if isArrayInitializationUsingConstructor node, astApi
+            error = astApi.createError
+                lineNumber: node.locationData.first_line + 1
+            @errors.push error
+        node.eachChild (child) => @lintNode child, astApi

--- a/test/test_array_initialization.coffee
+++ b/test/test_array_initialization.coffee
@@ -1,0 +1,34 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+vows.describe('array_initialization').addBatch({
+
+    'Array initialization using the Array constructor' :
+
+        topic : () ->
+            '''
+            a = []
+            a = new Array
+            '''
+
+        'is allowed by default' : (source) ->
+            errors = coffeelint.lint(source)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+        'can be forbidden' : (source) ->
+            config = {array_initialization : {level:'error'}}
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+            error = errors[0]
+            assert.equal(error.lineNumber, 2)
+            assert.equal(
+                error.message,
+                'Array initialization using the Array constructor is forbidden'
+            )
+            assert.equal(error.rule, 'array_initialization')
+
+}).export(module)


### PR DESCRIPTION
The [thoughtbot style guide](https://github.com/thoughtbot/guides/tree/dc293558279e3cc0d8365355334b334b477a7728/style#coffeescript) has a rule stating the following.

> Initialize arrays using `[]`.

In order to facilitate automatic enforcement of this rule I'm adding it as a CoffeeLint rule. The rule is disabled by default, since this rule is presumably quite specific to thoughtbot.
