### PR TITLE
fix no_implicit_parens. fixes #288

### DIFF
--- a/src/rules/no_implicit_parens.coffee
+++ b/src/rules/no_implicit_parens.coffee
@@ -30,11 +30,17 @@ module.exports = class NoImplicitParens
             else
                 # If strict mode is turned off it allows implicit parens when the
                 # expression is spread over multiple lines.
+                functionNesting = 1
+                last_line = token[2].last_line
                 i = -1
                 loop
                     t = tokenApi.peek(i)
-                    if not t? or t[0] == 'CALL_START'
+                    if t?[0] == 'CALL_END'
+                        functionNesting += 1
+                    if functionNesting == 1 and (not t? or t[0] == 'CALL_START')
                         return true
-                    if t.newLine
+                    if t[2].first_line < last_line || t[0] == 'INDENT'
                         return null
+                    if t?[0] == 'CALL_START'
+                        functionNesting -= 1
                     i -= 1

--- a/test/test_no_implicit_parens.coffee
+++ b/test/test_no_implicit_parens.coffee
@@ -42,6 +42,10 @@ vows.describe('parens').addBatch({
 
     'No implicit parens strict' :
         topic: """
+            blah = (a) ->
+            blah
+              foo: 'bar'
+
             blah = (a, b) ->
             blah 'a'
             , 'b'
@@ -51,7 +55,7 @@ vows.describe('parens').addBatch({
             config = {no_implicit_parens : {level:'error'}}
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
-            assert.lengthOf(errors, 1)
+            assert.lengthOf(errors, 2)
             assert.equal(rule, 'no_implicit_parens') for {rule} in errors
 
         "allows parens at the end of lines when strict is false": (source) ->
@@ -65,6 +69,10 @@ vows.describe('parens').addBatch({
 
     'Nested no implicit parens strict' :
         topic: """
+            blah = (a) ->
+            blah
+              foo: blah('a')
+
             blah = (a, b) ->
 
             blah 'a'
@@ -79,7 +87,7 @@ vows.describe('parens').addBatch({
             config = {no_implicit_parens : {level:'error'}}
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
-            assert.lengthOf(errors, 3)
+            assert.lengthOf(errors, 4)
             assert.equal(rule, 'no_implicit_parens') for {rule} in errors
 
         "allows parens at the end of lines when strict is false": (source) ->


### PR DESCRIPTION
allow line return of object literal to break function call when strict: false
