### PR TITLE
add fallback for path.sep in bin file

### DIFF
--- a/bin/coffeelint
+++ b/bin/coffeelint
@@ -27,7 +27,7 @@ if (!existsFn(commandline)) {
         // Try to find a project-specific install first. This works the same
         // way grunt-cli does.
         filepath = resolve('coffeelint', { basedir: process.cwd() });
-        commandline = path.dirname(filepath) + path.sep + 'commandline.js';
+        commandline = path.dirname(filepath) + (path.sep || '/') + 'commandline.js';
     } catch (ex) {
     }
 


### PR DESCRIPTION
In Node before [0.7.9](https://github.com/joyent/node/commit/782277), path.sep did not exist. When using the latest version of Coffeelint on an older version of Node, it throws the following error:

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Cannot find module 'node_modules/coffeelint/libundefinedcommandline.js'
    at Function._resolveFilename (module.js:332:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:354:17)
    at require (module.js:370:17)
    at Object.<anonymous> (node_modules/coffeelint/bin/coffeelint:34:5)
    at Module._compile (module.js:441:26)
    at Object..js (module.js:459:10)
    at Module.load (module.js:348:32)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:479:10)
```

I added the forward slash fallback. I also considered a platform check like `os.platform().match(/^win/) ? '\\' :'/'`, but thought that might be overkill.
