### PR TITLE
Fix implicit parens edge-case (for last line)

### DIFF
--- a/src/rules/no_implicit_parens.coffee
+++ b/src/rules/no_implicit_parens.coffee
@@ -1,4 +1,3 @@
-
 module.exports = class NoImplicitParens
 
     rule:
@@ -25,7 +24,7 @@ module.exports = class NoImplicitParens
 
     lintToken : (token, tokenApi) ->
         if token.generated
-            unless tokenApi.config[@rule.name].strict == false
+            unless tokenApi.config[@rule.name].strict is false
                 return true
             else
                 # If strict mode is turned off it allows implicit parens when the
@@ -33,8 +32,14 @@ module.exports = class NoImplicitParens
                 i = -1
                 loop
                     t = tokenApi.peek(i)
-                    if not t? or t[0] == 'CALL_START'
+
+                    if not t? or (t[0] is 'CALL_START' and t.generated)
                         return true
-                    if t.newLine
+
+                    # If we have not found a CALL_START token that is generated,
+                    # and we've moved into a new line, this is fine and should
+                    # just return.
+                    if t[2].first_line isnt token[2].first_line
                         return null
+
                     i -= 1

--- a/test/test_no_implicit_parens.coffee
+++ b/test/test_no_implicit_parens.coffee
@@ -47,17 +47,17 @@ vows.describe('parens').addBatch({
             , 'b'
         """
 
-        "blocks all implicit parens by default": (source) ->
+        'blocks all implicit parens by default' : (source) ->
             config = {no_implicit_parens : {level:'error'}}
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
             assert.equal(rule, 'no_implicit_parens') for {rule} in errors
 
-        "allows parens at the end of lines when strict is false": (source) ->
+        'allows parens at the end of lines when strict is false' : (source) ->
             config =
                 no_implicit_parens:
-                    level:'error'
+                    level: 'error'
                     strict: false
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
@@ -75,20 +75,59 @@ vows.describe('parens').addBatch({
             , 'd')
         """
 
-        "blocks all implicit parens by default": (source) ->
+        'blocks all implicit parens by default' : (source) ->
             config = {no_implicit_parens : {level:'error'}}
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 3)
-            assert.equal(rule, 'no_implicit_parens') for {rule} in errors
+            assert.equal(rule, 'no_implicit_parens') for { rule } in errors
 
-        "allows parens at the end of lines when strict is false": (source) ->
+        'allows parens at the end of lines when strict is false' : (source) ->
             config =
                 no_implicit_parens:
-                    level:'error'
+                    level: 'error'
                     strict: false
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
+
+    'Test for when implicit parens are on the last line' :
+        topic: """
+            class Something
+              constructor: ->
+                return $ '#something'
+
+              yo: ->
+
+            class AnotherSomething
+              constructor: ->
+                return $ '#something'
+
+            blah 'a'
+            , blah('c', 'd')
+
+        """
+
+        'throws three errors when strict is true' : (source) ->
+            config =
+                no_implicit_parens:
+                    level: 'error'
+                    strict: true
+
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 3)
+
+        # When implicit parens are separated out on multiple lines
+        # and strict is set to false, do not return an error.
+        'throws two errors when strict is false' : (source) ->
+            config =
+                no_implicit_parens:
+                    level: 'error'
+                    strict: false
+
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 2)
 
 }).export(module)


### PR DESCRIPTION
This is an attempt at fixing #302. Basically if you have strict set to
false as part of the no_implicit_parens config, it should allow implicit
parens when it's done across multiple lines.

Before the change was done by detecting for a newline. Unfortunately it
seems that CoffeeScript does not add a newline property so you can have
implicit parens on the last line of code.

Closes #302
