### PR TITLE
Fixes method chaining looking out of scope

### DIFF
--- a/test/test_indent.coffee
+++ b/test/test_indent.coffee
@@ -386,5 +386,22 @@ vows.describe('indent').addBatch({
         'is permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
+    'Make sure indentation check is not affected outside proper scope' :
+        topic : """
+            a
+              .b
+
+            c = ->
+              return d + e
+
+            ->
+              if a is c and
+                (false or
+                  long.expression.that.necessitates(linebreak))
+                @foo()
+            """
+        'returns no errors outside scope': (source) ->
+            errors = coffeelint.lint(source)
+            assert.isEmpty(errors)
 
 }).export(module)


### PR DESCRIPTION
This PR is a rewrite of the original code that was used to generate the
correct INDENT value for INDENT tokens when a user wrote code that used
method chaining with each new method on it's own particular line.

There is less redundant code, with a new function called
`getCorrectIndent` that will return the corrected INDENT value that
should be there instead of what CoffeeScript original generates.

This also fixes #305 where the original `isChainedCall` function was
looking out of its scope when checking for proper indenting in the
current method chain.
