### PR TITLE
Add rules folder as part of the linting process

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepublish": "cake prepublish",
     "publish": "cake publish",
     "install": "cake install",
-    "lint": "cake compile && ./bin/coffeelint -f coffeelint.json src/*.coffee test/*.coffee test/*.litcoffee",
+    "lint": "cake compile && ./bin/coffeelint -f coffeelint.json src/*.coffee src/rules/*.coffee test/*.coffee test/*.litcoffee",
     "lint-csv": "cake compile && ./bin/coffeelint --csv -f coffeelint.json src/*.coffee test/*.coffee",
     "lint-jslint": "cake compile && ./bin/coffeelint --jslint -f coffeelint.json src/*.coffee test/*.coffee",
     "compile": "cake compile"

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -52,8 +52,8 @@ class ErrorReport
         for path, errors of @paths
             pathCount++
             for error in errors
-                errorCount++ if error.level == 'error'
-                warningCount++ if error.level == 'warn'
+                errorCount++ if error.level is 'error'
+                warningCount++ if error.level is 'warn'
         return {errorCount, warningCount, pathCount}
 
     getErrors : (path) ->
@@ -72,7 +72,7 @@ class ErrorReport
 
     _hasLevel : (path, level) ->
         for error in @paths[path]
-            return true if error.level == level
+            return true if error.level is level
         return false
 
 

--- a/src/lexical_linter.coffee
+++ b/src/lexical_linter.coffee
@@ -44,8 +44,8 @@ module.exports = class LexicalLinter extends BaseLinter
     lintToken : (token) ->
         [type, value, lineNumber] = token
 
-        if typeof lineNumber == "object"
-            if type == 'OUTDENT' or type == 'INDENT'
+        if typeof lineNumber is "object"
+            if type is 'OUTDENT' or type is 'INDENT'
                 lineNumber = lineNumber.last_line
             else
                 lineNumber = lineNumber.first_line

--- a/src/line_linter.coffee
+++ b/src/line_linter.coffee
@@ -47,7 +47,7 @@ class LineApi
         null
 
     isLastLine : () ->
-        return @lineNumber == @lineCount - 1
+        return @lineNumber is @lineCount - 1
 
     # Return true if the given line actually has tokens.
     # Optional parameter to check for a specific token type and line number.
@@ -59,7 +59,7 @@ class LineApi
             tokens = @tokensByLine[lineNumber]
             return null unless tokens?
             for token in tokens
-                return true if token[0] == tokenType
+                return true if token[0] is tokenType
             return false
 
     # Return tokens for the given line number.

--- a/src/reporters/default.coffee
+++ b/src/reporters/default.coffee
@@ -66,7 +66,7 @@ module.exports = class Reporter
 
         for e in errors
             continue if @quiet and e.level != 'error'
-            o = if e.level == 'error' then @err else @warn
+            o = if e.level is 'error' then @err else @warn
             lineEnd = ""
             lineEnd = "-#{e.lineNumberEnd}" if e.lineNumberEnd?
             output = "#" + e.lineNumber + lineEnd
@@ -82,5 +82,5 @@ module.exports = class Reporter
         console.log message
 
     plural : (str, count) ->
-        if count == 1 then str else "#{str}s"
+        if count is 1 then str else "#{str}s"
 

--- a/src/rules/arrow_spacing.coffee
+++ b/src/rules/arrow_spacing.coffee
@@ -43,8 +43,6 @@ module.exports = class ArrowSpacing
 
         pp = tokenApi.peek(-1)
 
-
-
         if not token.spaced and
                 (pp[1] is "(" and not pp.generated?) and
                 tokenApi.peek(1)[0] is 'INDENT' and

--- a/src/rules/camel_case_classes.coffee
+++ b/src/rules/camel_case_classes.coffee
@@ -40,9 +40,9 @@ module.exports = class CamelCaseClasses
         className = null
         offset = 1
         until className
-            if tokenApi.peek(offset + 1)?[0] == '.'
+            if tokenApi.peek(offset + 1)?[0] is '.'
                 offset += 2
-            else if tokenApi.peek(offset)?[0] == '@'
+            else if tokenApi.peek(offset)?[0] is '@'
                 offset += 1
             else
                 className = tokenApi.peek(offset)[1]

--- a/src/rules/colon_assignment_spacing.coffee
+++ b/src/rules/colon_assignment_spacing.coffee
@@ -34,7 +34,7 @@ module.exports = class ColonAssignmentSpacing
     tokens : [':']
 
     lintToken : (token, tokenApi) ->
-        spacingAllowances = tokenApi.config[@rule.name].spacing
+        spaceRules = tokenApi.config[@rule.name].spacing
         previousToken = tokenApi.peek -1
         nextToken = tokenApi.peek 1
 
@@ -48,7 +48,11 @@ module.exports = class ColonAssignmentSpacing
         checkSpacing = (direction) ->
             spacing = getSpaceFromToken direction
             # when spacing is negative, the neighboring token is a newline
-            isSpaced = if spacing < 0 then true else spacing is parseInt spacingAllowances[direction]
+            isSpaced = if spacing < 0
+                true
+            else
+                spacing is parseInt spaceRules[direction]
+
             [isSpaced, spacing]
 
         [isLeftSpaced, leftSpacing] = checkSpacing 'left'
@@ -60,6 +64,6 @@ module.exports = class ColonAssignmentSpacing
             context :
                 """
                 Incorrect spacing around column #{token[2].first_column}.
-                Expected left: #{spacingAllowances.left}, right: #{spacingAllowances.right}.
+                Expected left: #{spaceRules.left}, right: #{spaceRules.right}.
                 Got left: #{leftSpacing}, right: #{rightSpacing}.
                 """

--- a/src/rules/cyclomatic_complexity.coffee
+++ b/src/rules/cyclomatic_complexity.coffee
@@ -12,9 +12,9 @@ module.exports = class NoTabs
         name = @astApi.getNodeName node
         complexity = if name in ['If', 'While', 'For', 'Try']
             1
-        else if name == 'Op' and node.operator in ['&&', '||']
+        else if name is 'Op' and node.operator in ['&&', '||']
             1
-        else if name == 'Switch'
+        else if name is 'Switch'
             node.cases.length
         else
             0
@@ -40,7 +40,7 @@ module.exports = class NoTabs
 
         # If the current node is a function, and it's over our limit, add an
         # error to the list.
-        if name == 'Code' and complexity >= rule.value
+        if name is 'Code' and complexity >= rule.value
             error = @astApi.createError {
                 context: complexity + 1
                 lineNumber: line + 1

--- a/src/rules/duplicate_key.coffee
+++ b/src/rules/duplicate_key.coffee
@@ -12,18 +12,18 @@ module.exports = class DuplicateKey
         description:
             "Prevents defining duplicate keys in object literals and classes"
 
-    tokens: [ 'IDENTIFIER', "{","}" ]
+    tokens: [ 'IDENTIFIER', '{', '}' ]
 
     constructor: ->
         @braceScopes = []   # A stack tracking keys defined in nexted scopes.
 
     lintToken : ([type], tokenApi) ->
 
-        if type in [ "{","}" ]
+        if type in [ '{', '}' ]
             @lintBrace arguments...
             return undefined
 
-        if type is "IDENTIFIER"
+        if type is 'IDENTIFIER'
             @lintIdentifier arguments...
 
     lintIdentifier : (token, tokenApi) ->
@@ -40,7 +40,7 @@ module.exports = class DuplicateKey
         previousToken = tokenApi.peek(-1)
 
         # Assigning "@something" and "something" are not the same thing
-        key = "@#{key}" if previousToken[0] == '@'
+        key = "@#{key}" if previousToken[0] is '@'
 
         # Added a prefix to not interfere with things like "constructor".
         key = "identifier-#{key}"
@@ -51,7 +51,7 @@ module.exports = class DuplicateKey
             null
 
     lintBrace : (token) ->
-        if token[0] == '{'
+        if token[0] is '{'
             @braceScopes.push @currentScope if @currentScope?
             @currentScope = {}
         else

--- a/src/rules/line_endings.coffee
+++ b/src/rules/line_endings.coffee
@@ -18,9 +18,9 @@ module.exports = class LineEndings
         return null if not ending or lineApi.isLastLine() or not line
 
         lastChar = line[line.length - 1]
-        valid = if ending == 'windows'
-            lastChar == '\r'
-        else if ending == 'unix'
+        valid = if ending is 'windows'
+            lastChar is '\r'
+        else if ending is 'unix'
             lastChar != '\r'
         else
             throw new Error("unknown line ending type: #{ending}")

--- a/src/rules/no_implicit_braces.coffee
+++ b/src/rules/no_implicit_braces.coffee
@@ -40,13 +40,13 @@ module.exports = class NoImplicitBraces
 
 
     isPartOfClass: (tokenApi) ->
-            # Peek back to the last line break. If there is a class
-            # definition, ignore the generated brace.
-            i = -1
-            loop
-                t = tokenApi.peek(i)
-                if not t? or t[0] == 'TERMINATOR'
-                    return true
-                if t[0] == 'CLASS'
-                    return null
-                i -= 1
+        # Peek back to the last line break. If there is a class
+        # definition, ignore the generated brace.
+        i = -1
+        loop
+            t = tokenApi.peek(i)
+            if not t? or t[0] is 'TERMINATOR'
+                return true
+            if t[0] is 'CLASS'
+                return null
+            i -= 1

--- a/src/rules/no_implicit_parens.coffee
+++ b/src/rules/no_implicit_parens.coffee
@@ -20,15 +20,15 @@ module.exports = class NoImplicitParens
             """
 
 
-    tokens: [ "CALL_END" ]
+    tokens: [ 'CALL_END' ]
 
     lintToken : (token, tokenApi) ->
         if token.generated
             unless tokenApi.config[@rule.name].strict is false
                 return true
             else
-                # If strict mode is turned off it allows implicit parens when the
-                # expression is spread over multiple lines.
+                # If strict mode is turned off it allows implicit parens when
+                # the expression is spread over multiple lines.
                 i = -1
                 loop
                     t = tokenApi.peek(i)

--- a/src/rules/no_interpolation_in_single_quotes.coffee
+++ b/src/rules/no_interpolation_in_single_quotes.coffee
@@ -16,7 +16,7 @@ module.exports = class NoInterpolationInSingleQuotes
             foo = "#{bar}"
             </code>
             </pre>
-            String interpolation in single quoted strings is permitted by 
+            String interpolation in single quoted strings is permitted by
             default.
             '''
 

--- a/src/rules/no_stand_alone_at.coffee
+++ b/src/rules/no_stand_alone_at.coffee
@@ -13,22 +13,22 @@ module.exports = class NoStandAloneAt
             """
 
 
-    tokens: [ "@" ]
+    tokens: [ '@' ]
 
     lintToken : (token, tokenApi) ->
         nextToken = tokenApi.peek()
         spaced = token.spaced
-        isIdentifier = nextToken[0] == 'IDENTIFIER'
-        isIndexStart = nextToken[0] == 'INDEX_START'
-        isDot = nextToken[0] == '.'
+        isIdentifier = nextToken[0] is 'IDENTIFIER'
+        isIndexStart = nextToken[0] is 'INDEX_START'
+        isDot = nextToken[0] is '.'
 
         # https://github.com/jashkenas/coffee-script/issues/1601
         # @::foo is valid, but @:: behaves inconsistently and is planned for
         # removal. Technically @:: is a stand alone ::, but I think it makes
         # sense to group it into no_stand_alone_at
-        if nextToken[0] == '::'
+        if nextToken[0] is '::'
             protoProperty = tokenApi.peek(2)
-            isValidProtoProperty = protoProperty[0] == 'IDENTIFIER'
+            isValidProtoProperty = protoProperty[0] is 'IDENTIFIER'
 
         if spaced or (not isIdentifier and not isIndexStart and
         not isDot and not isValidProtoProperty)

--- a/src/rules/no_throwing_strings.coffee
+++ b/src/rules/no_throwing_strings.coffee
@@ -26,11 +26,11 @@ module.exports = class NoThrowingStrings
             This rule is enabled by default.
             """
 
-    tokens: [ "THROW" ]
+    tokens: [ 'THROW' ]
 
     lintToken : (token, tokenApi) ->
         [n1, n2] = [tokenApi.peek(), tokenApi.peek(2)]
         # Catch literals and string interpolations, which are wrapped in
         # parens.
-        nextIsString = n1[0] == 'STRING' or (n1[0] == '(' and n2[0] == 'STRING')
+        nextIsString = n1[0] is 'STRING' or (n1[0] is '(' and n2[0] is 'STRING')
         return nextIsString

--- a/src/rules/no_trailing_semicolons.coffee
+++ b/src/rules/no_trailing_semicolons.coffee
@@ -29,22 +29,26 @@ module.exports = class NoTrailingSemicolons
         # result a line with a comment DOES have a token: the TERMINATOR from
         # the last line of code.
         lineTokens = lineApi.getLineTokens()
-        if lineTokens.length is 1 and lineTokens[0][0] in ['TERMINATOR', 'HERECOMMENT']
+        tokenLen = lineTokens.length
+        stopTokens = ['TERMINATOR', 'HERECOMMENT']
+
+        if tokenLen is 1 and lineTokens[0][0] in stopTokens
             return
 
         newLine = line
-        if lineTokens.length > 1 and lineTokens[lineTokens.length - 1][0] is 'TERMINATOR'
+        if tokenLen > 1 and lineTokens[tokenLen - 1][0] is 'TERMINATOR'
 
-            # startPos contains the end position of the last non-TERMINATOR token
-            # endPos contains the start position of the TERMINATOR token
+            # `startPos` contains the end pos of the last non-TERMINATOR token
+            # `endPos` contains the start position of the TERMINATOR token
+
             # if startPos and endPos arent equal, that probably means a comment
             # was sliced out of the tokenizer
 
-            startPos = lineTokens[lineTokens.length - 2][2].last_column + 1
-            endPos = lineTokens[lineTokens.length - 1][2].first_column
+            startPos = lineTokens[tokenLen - 2][2].last_column + 1
+            endPos = lineTokens[tokenLen - 1][2].first_column
             if (startPos isnt endPos)
                 startCounter = startPos
-                while line[startCounter] isnt "#" and startCounter < line.length
+                while line[startCounter] isnt '#' and startCounter < line.length
                     startCounter++
                 newLine = line.substring(0, startCounter).replace(/\s*$/, '')
 

--- a/src/rules/no_trailing_whitespace.coffee
+++ b/src/rules/no_trailing_whitespace.coffee
@@ -37,7 +37,7 @@ module.exports = class NoTrailingWhitespace
 
             # To avoid confusion when a string might contain a "#", every string
             # on this line will be removed. before checking for a comment
-            for str in (token[1] for token in tokens when token[0] == 'STRING')
+            for str in (token[1] for token in tokens when token[0] is 'STRING')
                 line = line.replace(str, 'STRING')
 
             if !regexes.lineHasComment.test(line)

--- a/src/rules/no_unnecessary_double_quotes.coffee
+++ b/src/rules/no_unnecessary_double_quotes.coffee
@@ -7,7 +7,7 @@ module.exports = class NoUnnecessaryDoubleQuotes
         level : 'ignore'
         message : 'Unnecessary double quotes are forbidden'
         description: '''
-            This rule prohibits double quotes unless string interpolation is 
+            This rule prohibits double quotes unless string interpolation is
             used or the string contains single quotes.
             <pre>
             <code># Double quotes are discouraged:

--- a/src/rules/space_operators.coffee
+++ b/src/rules/space_operators.coffee
@@ -7,8 +7,8 @@ module.exports = class SpaceOperators
         message : 'Operators must be spaced properly'
         description: "This rule enforces that operators have space around them."
 
-    tokens: [ "+", "-", "=", "**", "MATH", "COMPARE", "LOGIC",
-        "COMPOUND_ASSIGN", "(", ")", "CALL_START", "CALL_END" ]
+    tokens: [ '+', '-', '=', '**', 'MATH', 'COMPARE', 'LOGIC',
+        'COMPOUND_ASSIGN', '(', ')', 'CALL_START', 'CALL_END' ]
 
     constructor: ->
         @callTokens = []    # A stack tracking the call token pairs.
@@ -17,16 +17,16 @@ module.exports = class SpaceOperators
     lintToken : ([type], tokenApi) ->
 
         # These just keep track of state
-        if type in [ "CALL_START", "CALL_END" ]
+        if type in [ 'CALL_START', 'CALL_END' ]
             @lintCall arguments...
             return undefined
-        if type in [ "(", ")" ]
+        if type in [ '(', ')' ]
             @lintParens arguments...
             return undefined
 
 
         # These may return errors
-        if type in [ "+", "-" ]
+        if type in [ '+', '-' ]
             @lintPlus arguments...
         else
             @lintMath arguments...
@@ -61,11 +61,11 @@ module.exports = class SpaceOperators
         return false
 
     lintCall : (token, tokenApi) ->
-        if token[0] == 'CALL_START'
+        if token[0] is 'CALL_START'
             p = tokenApi.peek(-1)
             # Track regex calls, to know (approximately) if we're in an
             # extended regex.
-            token.isRegex = p and p[0] == 'IDENTIFIER' and p[1] == 'RegExp'
+            token.isRegex = p and p[0] is 'IDENTIFIER' and p[1] is 'RegExp'
             @callTokens.push(token)
         else
             @callTokens.pop()
@@ -77,14 +77,14 @@ module.exports = class SpaceOperators
         return false
 
     lintParens : (token, tokenApi) ->
-        if token[0] == '('
+        if token[0] is '('
             p1 = tokenApi.peek(-1)
             n1 = tokenApi.peek(1)
             n2 = tokenApi.peek(2)
             # String interpolations start with '' + so start the type co-ercion,
             # so track if we're inside of one. This is most definitely not
             # 100% true but what else can we do?
-            i = n1 and n2 and n1[0] == 'STRING' and n2[0] == '+'
+            i = n1 and n2 and n1[0] is 'STRING' and n2[0] is '+'
             token.isInterpolation = i
             @parenTokens.push(token)
         else

--- a/test/test_1.5.0_plus.coffee
+++ b/test/test_1.5.0_plus.coffee
@@ -7,8 +7,8 @@ CoffeeScript.tokens = (text) ->
     CoffeeScript.updated_tokens_called = true
     tokens = CoffeeScript.old_tokens(text)
     for token in tokens
-        if typeof token[2] == "number"
-            if token[0] == 'INDENT' or token[1] == 'OUTDENT'
+        if typeof token[2] is "number"
+            if token[0] is 'INDENT' or token[1] is 'OUTDENT'
                 token[2] = {first_line: token[2] - 1, last_line: token[2]}
             else
                 token[2] = {first_line: token[2], last_line: token[2]}
@@ -38,7 +38,7 @@ vows.describe("CoffeeScript 1.5.0+").addBatch({
             assert.equal(error.rule, 'no_trailing_semicolons')
 
     "for indentation last_line is the correct value for lineNumber" :
-        
+
         topic : () ->
             """
             x = () ->


### PR DESCRIPTION
This includes the src/rules folder as part of the linting process for
the library. This means that when you run `npm test` it will now also
lint src/rules.

Also fixes errors being generated from CoffeeScript files in the rules
folder.

Note there are now 2 more warnings for cyclomatic complexity.
