### PR TITLE
Fix an edgecase bug for no_trailing_semicolons

### DIFF
--- a/src/rules/no_trailing_semicolons.coffee
+++ b/src/rules/no_trailing_semicolons.coffee
@@ -1,6 +1,5 @@
-
 regexes =
-    trailingSemicolon : /;\r?$/
+    trailingSemicolon: /;\r?$/
 
 module.exports = class NoTrailingSemicolons
 
@@ -55,8 +54,10 @@ module.exports = class NoTrailingSemicolons
         hasSemicolon = regexes.trailingSemicolon.test(newLine)
         [first..., last] = lineTokens
         hasNewLine = last and last.newLine?
-        # Don't throw errors when the contents of  multiline strings,
+        # Don't throw errors when the contents of multiline strings,
         # regexes and the like end in ";"
+        #
+        # `CALL_END` Added because of #314
         if hasSemicolon and not hasNewLine and lineApi.lineHasToken() and
-                not (last[0] in ['STRING', 'IDENTIFIER'])
+                not (last[0] in ['STRING', 'IDENTIFIER', 'CALL_END'])
             return true

--- a/test/test_semicolons.coffee
+++ b/test/test_semicolons.coffee
@@ -118,4 +118,31 @@ vows.describe('semicolons').addBatch({
             assert.equal(error.message, "Line contains a trailing semicolon")
             assert.equal(error.rule, 'no_trailing_semicolons')
 
+    'Semicolons inside of blockquote string' :
+        topic : () ->
+            '''
+            foo = bar();
+
+            errs = """
+              this does not err;
+              this does;
+              #{isEmpty a};
+              #{isEmpty(b)};
+            """
+
+            nothing = """
+            this does not err;
+            this neither;
+            #{isEmpty(x)};
+            #{isEmpty y};
+            """
+            '''
+        'are ignored' : (source) ->
+            errors = coffeelint.lint(source, configError)
+            assert.lengthOf(errors, 1)
+            error = errors[0]
+            assert.equal(error.lineNumber, 1)
+            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.rule, 'no_trailing_semicolons')
+
 }).export(module)


### PR DESCRIPTION
This is to fix an edge case bug where, inside of a multiline string,
there is an interpolated string where the entire interpolation is a
function call and does not contain a variable/string.

Fixes #314
