### PR TITLE
Config: Prioritize userprofile for HOME search

### DIFF
--- a/src/configfinder.coffee
+++ b/src/configfinder.coffee
@@ -47,7 +47,7 @@ exports.getConfig = (filename = null) ->
         return npmConfig  if npmConfig
         projConfig = findFile("coffeelint.json", dir)
         return loadJSON(projConfig)  if projConfig
-    envs = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
+    envs = process.env.USERPROFILE or process.env.HOME or process.env.HOMEPATH
     home = path.normalize(path.join(envs, "coffeelint.json"))
     if fs.existsSync(home)
         console.log 'loaded', home


### PR DESCRIPTION
In Windows, it turns out if the current user is
not the default user, environment.HOME
returns drive root instead of the user-profile
directory.
This PR changes the priority. This change will
not break the current usage / implementations.
