### PR TITLE
New rule: Ensure List Comprehensions (attempt at a first pass)

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -113,7 +113,7 @@ coffeelint.registerRule = (RuleConstructor, ruleName = undefined) ->
 
     if typeof p.lintToken is 'function'
         e "'tokens' is required for 'lintToken'" unless p.tokens
-    else if typeof p.lintLine  isnt 'function' and
+    else if typeof p.lintLine isnt 'function' and
             typeof p.lintAST isnt 'function'
         e "Rules must implement lintToken, lintLine, or lintAST"
 
@@ -161,6 +161,7 @@ coffeelint.registerRule(
 )
 coffeelint.registerRule require './rules/no_empty_functions.coffee'
 coffeelint.registerRule require './rules/prefer_english_operator.coffee'
+coffeelint.registerRule require './rules/ensure_comprehensions.coffee'
 
 hasSyntaxError = (source) ->
     try

--- a/src/rules/ensure_comprehensions.coffee
+++ b/src/rules/ensure_comprehensions.coffee
@@ -1,0 +1,52 @@
+module.exports = class EnsureComprehensions
+
+    rule:
+        name: 'ensure_comprehensions'
+        level: 'warn'
+        message: 'Comprehensions must have parentheses around them'
+        description:
+            'This rule makes sure that parentheses are around comprehensions.'
+
+    tokens: ['FOR']
+
+    lintToken: (token, tokenApi) ->
+        # Rules
+        # Ignore if normal for-loop with a block
+        # If LHS of operation contains either the key or value variable of
+        #     the loop, assume that it is not a comprehension.
+
+        idents = @findIdents(tokenApi)
+
+        peeker = -1
+        atEqual = false
+        prevIdents = []
+        while (prevToken = tokenApi.peek(peeker))
+            if prevToken[0] is 'IDENTIFIER'
+                if not atEqual
+                    prevIdents.push prevToken[1]
+                else if prevToken[1] in idents
+                    return
+
+            if prevToken[0] in ['(', '->', 'TERMINATOR'] or prevToken.newLine?
+                break
+            if prevToken[0] is '='
+                atEqual = true
+            peeker--
+
+        # If we hit a terminal node (TERMINATOR token or w/ property newLine)
+        # or if we hit the top of the file and we've seen an '=' sign without
+        # any identifiers that are part of the for-loop, or
+        if atEqual and prevIdents.length > 0
+            return { context: '' }
+
+    findIdents: (tokenApi) ->
+        peeker = 1
+        idents = []
+
+        while (nextToken = tokenApi.peek(peeker))
+            if nextToken[0] is 'IDENTIFIER'
+                idents.push(nextToken[1])
+            if nextToken[0] in ['FORIN', 'FOROF']
+                break
+            peeker++
+        return idents

--- a/test/test_ensure_comprehensions.coffee
+++ b/test/test_ensure_comprehensions.coffee
@@ -1,0 +1,145 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+ruleName = 'ensure_comprehensions'
+errorMessage = 'Comprehensions must have parentheses around them'
+config = {}
+
+vows.describe(ruleName).addBatch({
+
+    'Ignore for-loops':
+        topic:
+            '''
+            y = y + 5
+
+            for x in xlist
+              console.log x
+
+            if a is b
+              for x in xlist
+                console.log x
+            '''
+
+        'are ignored' : (source) ->
+            config[ruleName] = { level: 'error' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+    'When forgetting parens':
+        topic:
+            '''
+            for x in xlist
+              console.log x
+
+            doubleIt = x * 2 for x in singles
+
+            if a is b
+              for x in xlist
+                console.log x
+            '''
+
+        'throws an error': (source) ->
+            config[ruleName] = { level: 'error' }
+
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+
+            error = errors[0]
+            assert.equal(error.lineNumber, 4)
+            assert.equal(error.message, errorMessage)
+            assert.equal(error.rule, ruleName)
+
+        'doesn\'t throw an error when rule is ignore': (source) ->
+            config[ruleName] = { level: 'ignore' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+    'Doesn\'t trigger if we encounter key/value of the loop before equal sign':
+        topic:
+            '''
+            sum = 0
+            nums = [1, 2, 3, 4, 5]
+            for n in nums
+              sum += n
+
+            sum = n for n in nums // error triggers without parens
+
+            newConfig[key] = value for key, value of config
+            '''
+
+        'doesn\'t throw an error': (source) ->
+            config[ruleName] = { level: 'error' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+
+            error = errors[0]
+            assert.equal(error.lineNumber, 6)
+            assert.equal(error.message, errorMessage)
+            assert.equal(error.rule, ruleName)
+
+    'Doesn\'t trigger if we encounter key/value and there is no equal sign':
+        topic:
+            '''
+            sum = 0
+            nums = [1, 2, 3, 4, 5]
+            for n in nums
+              sum += n
+
+            sum += n for n in nums
+
+            eat food for food in foods when food isnt 'chocolate'
+            '''
+
+        'doesn\'t throw an error': (source) ->
+            config[ruleName] = { level: 'error' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+    'Doesn\'t trigger when variable is set to a for-loop with a block':
+        topic:
+            '''
+            myLines = for row in [start..end]
+              if row[start] is ' '
+                line = true
+              else
+                line = false
+              line
+            '''
+
+        'doesn\'t throw an error': (source) ->
+            config[ruleName] = { level: 'error' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+    'Functions return all comprehensions as an array':
+        topic:
+            '''
+            myLines = ->
+              (row[start] + "!" for row in [start..end])
+
+            myLines = ->
+              row[start] + "!" for row in [start..end]
+
+            myLines = -> row[start] + "!" for row in [start..end]
+
+            myLines = -> (row[start] + "!" for row in [start..end])
+
+            '''
+
+        'doesn\'t throw an error': (source) ->
+            config[ruleName] = { level: 'error' }
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+
+
+}).export(module)


### PR DESCRIPTION
- Closes #237 (if accepted)
- Set to 'warn' as the default level
- Better name for the rule than this?

This new rule makes sure that the user remembers to put parentheses
around any list comprehensions they make. Not putting parentheses around
a list comprehension is generally a mistake since they actually want the
whole list and not just a value.

This rule will ignore for-loops with a block, and will ignore for-loops
where an identifier on the left-hand-side of the assignment operator is
either a key, value or index identifier of the for loop

E.g.

``` coffeescript
newConfig[key] = value for key, value of config
```
