### PR TITLE
Added support for the CoffeeReactTransform

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "browserify": "~3.37",
+    "coffee-react-transform": "^1.0.2",
     "coffee-script": "~1.7",
     "coffeeify": "~0.6.0",
     "glob": "^4.0.0",

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -24,6 +24,7 @@ else
     # which breaks NodeJS
     # https://github.com/substack/node-browserify/issues/471
     CoffeeScript = nodeRequire 'coffee-script'
+    CoffeeReactTransform = nodeRequire 'coffee-react-transform'
 
 # Browserify will inline the file at compile time.
 packageJSON = require('./../package.json')
@@ -222,6 +223,10 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
                     unless r of config and config[r].level in ['warn','error']
                         disabled_initially.push r
                         config[r] = { level: 'error' }
+
+    # Do cjsx transform when configured
+    if userConfig['cjsx']?['transform']? == true
+      source = CoffeeReactTransform(source)
 
     # Do AST linting first so all compile errors are caught.
     astErrors = new ASTLinter(source, config, _rules, CoffeeScript).lint()


### PR DESCRIPTION
With some inspiration from @leyyinad ( c7cafb1fa857b30d67c8c8ed63f406556fb6005e ), I created this really simple pull request to add optional cjsx support. There are some issues where I want to have feedback on:
- config only supports options from rules, no 'global' rules, how should i fix this? (currently using `userConfig` as a workaround)
- this is really cjsx specific, maybe a transform option where you can specify different transformers? 
- the `CoffeeReactTransform` never throws an error it just doesn't compile if it isn't recognized as valid cjsx
- are there any chances this could get merged?
