### PR TITLE
improve help message for noconfig option

### DIFF
--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -136,8 +136,7 @@ options = optimist
             .describe("f", "Specify a custom configuration file.")
             .describe("rules", "Specify a custom rule or directory of rules.")
             .describe("makeconfig", "Prints a default config file")
-            .describe("noconfig",
-                "Ignores the environment variable COFFEELINT_CONFIG.")
+            .describe("noconfig", "Ignores any config file.")
             .describe("h", "Print help information.")
             .describe("v", "Print current version number.")
             .describe("r", "(not used, but left for backward compatibility)")


### PR DESCRIPTION
The help message of noconfig flag currently states that only the `COFFEELINT_CONFIG` environment variable is being ignored.

But looking at:
https://github.com/clutchski/coffeelint/blob/48cd906b4b403cc7e949fe5e630a89dd413c6ba6/src/commandline.coffee#L65
https://github.com/clutchski/coffeelint/blob/48cd906b4b403cc7e949fe5e630a89dd413c6ba6/src/commandline.coffee#L190

It seems that it completely ignores all config files.

This lead to some confusion in a change to phabricator: https://secure.phabricator.com/D11196