### PR TITLE
Fix single quote interpolation's regex

### DIFF
--- a/src/rules/no_interpolation_in_single_quotes.coffee
+++ b/src/rules/no_interpolation_in_single_quotes.coffee
@@ -24,6 +24,6 @@ module.exports = class NoInterpolationInSingleQuotes
 
     lintToken : (token, tokenApi) ->
         tokenValue = token[1]
-
-        hasInterpolation = tokenValue.match(/#\{[^}]+\}/)
+        interpolationRe = /#\{[^!#%&\(\)\*\+,\-\.\/:;<=>\?@\[\/\]\^_\{\|\}~]+\}/
+        hasInterpolation = tokenValue.match(interpolationRe)
         return hasInterpolation

--- a/test/test_no_interpolation_in_single_quotes.coffee
+++ b/test/test_no_interpolation_in_single_quotes.coffee
@@ -28,6 +28,18 @@ vows.describe('no_interpolation_in_single_quotes').addBatch({
             )
             assert.equal(error.rule, 'no_interpolation_in_single_quotes')
 
+    'False interpolation in single quotes' :
+
+        topic : () ->
+            '''
+            foo = '#{= inter}foo#{#polation}'
+            '''
+
+        'interpolation in single quotes can be forbidden' : (source) ->
+            config = {no_interpolation_in_single_quotes : {level:'error'}}
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.isEmpty(errors)
 
     'Interpolation in double quotes' :
 


### PR DESCRIPTION
Previously its caused a false match on strings like `'#{= hash}` which
is not valid.
Such template engine used in grunt-hashmap.

According to [stackoverflow](http://stackoverflow.com/questions/1661197/valid-characters-for-javascript-variable-names) javascript's variable cannot start with any of provided by me characters.