### PR TITLE
braces_padding

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -129,6 +129,7 @@ coffeelint.getRules = ->
 
 # These all need to be explicitly listed so they get picked up by browserify.
 coffeelint.registerRule require './rules/arrow_spacing.coffee'
+coffeelint.registerRule require './rules/braces_spacing.coffee'
 coffeelint.registerRule require './rules/no_tabs.coffee'
 coffeelint.registerRule require './rules/no_trailing_whitespace.coffee'
 coffeelint.registerRule require './rules/max_line_length.coffee'

--- a/src/rules/braces_spacing.coffee
+++ b/src/rules/braces_spacing.coffee
@@ -1,0 +1,67 @@
+module.exports = class BracesSpacing
+
+    rule:
+        name: 'braces_spacing'
+        level: 'ignore'
+        spaces: 0
+        message: 'Curly braces must have the proper spacing'
+        description: '''
+            This rule checks to see that there is the proper spacing inside
+            curly braces. The spacing amount is specified by "spaces".
+
+            <pre><code>
+            # Spaces is 0
+            {a: b}     # Good
+            {a: b }    # Bad
+            { a: b}    # Bad
+            { a: b }   # Bad
+
+            # Spaces is 1
+            {a: b}     # Bad
+            {a: b }    # Bad
+            { a: b}    # Bad
+            { a: b }   # Good
+            { a: b  }  # Bad
+            {  a: b }  # Bad
+            {  a: b  } # Bad
+            </code></pre>
+
+            This rule is disabled by default.
+            '''
+
+    tokens: ['{', '}']
+
+    distanceBetweenTokens: (firstToken, secondToken) ->
+        secondToken[2].first_column - firstToken[2].last_column - 1
+
+    findNearestToken: (token, tokenApi, difference) ->
+        totalDifference = 0
+        while true
+            totalDifference += difference
+            nearestToken = tokenApi.peek(totalDifference)
+            continue if nearestToken[0] is 'OUTDENT'
+            return nearestToken
+
+    tokensOnSameLine: (firstToken, secondToken) ->
+        firstToken[2].first_line is secondToken[2].first_line
+
+    lintToken: (token, tokenApi) ->
+        return null if token.generated
+
+        [firstToken, secondToken] = if token[0] is '{'
+            [token, @findNearestToken(token, tokenApi, 1)]
+        else
+            [@findNearestToken(token, tokenApi, -1), token]
+
+        return null unless @tokensOnSameLine firstToken, secondToken
+
+        expected = tokenApi.config[@rule.name].spaces
+        actual = @distanceBetweenTokens firstToken, secondToken
+
+        if actual is expected
+            null
+        else
+            msg = "There should be #{expected} space"
+            msg += 's' unless expected is 1
+            msg += " inside \"#{token[0]}\""
+            context: msg

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -1,0 +1,159 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+sources =
+    implicit: 'foo: bar'
+    ownLine: '''
+             x = {
+               foo: bar
+             }
+             '''
+    sameLine:
+        noSpaces: '{foo: bar}'
+        oneSpace: '{ foo: bar }'
+        twoSpaces: '{  foo: bar  }'
+    splitLine:
+        noSpaces: '''
+                  {foo,
+                   bar} = x
+                  '''
+        oneSpace: '''
+                  { foo,
+                    bar } = x
+                  '''
+        twoSpaces: '''
+                   {  foo,
+                      bar  } = x
+                   '''
+    stringInterpolation:
+        noSpaces: "\"\#{foo}\""
+        oneSpace: "\"\#{ foo }\""
+
+configs =
+    zeroSpaces:
+        braces_spacing: {level: 'error', spaces: 0}
+    oneSpace:
+        braces_spacing: {level: 'error', spaces: 1}
+
+shouldPass = (source, config = {}) ->
+    topic: coffeelint.lint(source, config)
+    'returns no errors': (errors) ->
+        assert.isEmpty(errors)
+
+shouldFail = (source, config, errorMessages = []) ->
+    context = {}
+    context.topic = coffeelint.lint(source, config)
+    context["returns #{errorMessages.length} errors"] = (errors) ->
+        assert.equal(errors.length, errorMessages.length)
+        for error, index in errors
+            assert.equal(error.context, errorMessages[index])
+    context
+
+vows.describe('braces_spacing').addBatch({
+
+    'disabled by default' :
+        'with no spaces': shouldPass(sources.sameLine.noSpaces)
+        'with one space': shouldPass(sources.sameLine.oneSpace)
+
+
+    'enabled with spaces set to 0' :
+        'implicit braces':
+            shouldPass(sources.implicit, configs.zeroSpaces)
+
+        'braces on their own lines':
+            shouldPass(sources.ownLine, configs.zeroSpaces)
+
+        'braces on the line':
+            'no spaces inside both braces':
+                shouldPass(sources.sameLine.noSpaces, configs.zeroSpaces)
+
+            'one space inside on both braces':
+                shouldFail(sources.sameLine.oneSpace,
+                           configs.zeroSpaces,
+                           ['There should be 0 spaces inside "{"',
+                            'There should be 0 spaces inside "}"'])
+
+            'two spaces inside on both braces':
+                shouldFail(sources.sameLine.twoSpaces,
+                           configs.zeroSpaces,
+                           ['There should be 0 spaces inside "{"',
+                            'There should be 0 spaces inside "}"'])
+
+        'braces on separate lines':
+            'no spaces inside both braces':
+                shouldPass(sources.splitLine.noSpaces, configs.zeroSpaces)
+
+            'one space inside on both braces':
+                shouldFail(sources.splitLine.oneSpace,
+                           configs.zeroSpaces,
+                           ['There should be 0 spaces inside "{"',
+                            'There should be 0 spaces inside "}"'])
+
+            'two spaces inside on both braces':
+                shouldFail(sources.splitLine.twoSpaces,
+                           configs.zeroSpaces,
+                           ['There should be 0 spaces inside "{"',
+                            'There should be 0 spaces inside "}"'])
+
+        'string interpolation':
+            'no spaces inside both braces': ->
+                shouldPass(sources.stringInterpolation.noSpaces,
+                           configs.zeroSpaces)
+
+            'one space inside on both braces':
+                shouldPass(sources.stringInterpolation.oneSpace,
+                           configs.zeroSpaces)
+
+
+    'enabled with spaces set to 1' :
+        'implicit braces':
+            shouldPass(sources.implicit, configs.oneSpace)
+
+        'braces on their own lines':
+            shouldPass(sources.ownLine, configs.oneSpace)
+
+        'braces on the line':
+            'no spaces inside both braces':
+                shouldFail(sources.sameLine.noSpaces,
+                           configs.oneSpace,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
+
+            'one space inside on both braces':
+                shouldPass(sources.sameLine.oneSpace, configs.oneSpace)
+
+            'two spaces inside on both braces':
+                shouldFail(sources.sameLine.twoSpaces,
+                           configs.oneSpace,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
+
+        'braces on separate lines':
+            'no spaces inside both braces':
+                shouldFail(sources.splitLine.noSpaces,
+                           configs.oneSpace,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
+
+            'one space inside on both braces':
+                shouldPass(sources.splitLine.oneSpace, configs.oneSpace)
+
+            'two spaces inside on both braces':
+                shouldFail(sources.splitLine.twoSpaces,
+                           configs.oneSpace,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
+
+        'string interpolation':
+            'no spaces inside both braces':
+                shouldPass(sources.stringInterpolation.noSpaces,
+                           configs.oneSpace)
+
+            'one space inside on both braces':
+                shouldPass(sources.stringInterpolation.oneSpace,
+                           configs.oneSpace)
+
+
+}).export(module)


### PR DESCRIPTION
currently implement as a plugin at [charlierudolph/coffeelint-braces-padding](https://github.com/charlierudolph/coffeelint-braces-padding) but thought this is something that should be included in the core. Would be very easy to extend this for `brackets_padding` and `parens_padding`