### PR TITLE
Fix no_implicit_braces error in class declarations

### DIFF
--- a/src/lexical_linter.coffee
+++ b/src/lexical_linter.coffee
@@ -19,7 +19,7 @@ BaseLinter = require './base_linter.coffee'
 #
 module.exports = class LexicalLinter extends BaseLinter
 
-    constructor : (source, config, rules, CoffeeScript) ->
+    constructor: (source, config, rules, CoffeeScript) ->
         super source, config, rules
 
         @tokenApi = new TokenApi CoffeeScript, source, @config, @tokensByLine
@@ -31,7 +31,7 @@ module.exports = class LexicalLinter extends BaseLinter
         return typeof rule.lintToken is 'function'
 
     # Return a list of errors encountered in the given source.
-    lint : () ->
+    lint: () ->
         errors = []
 
         for token, i in @tokenApi.tokens
@@ -41,7 +41,7 @@ module.exports = class LexicalLinter extends BaseLinter
 
 
     # Return an error if the given token fails a lint check, false otherwise.
-    lintToken : (token) ->
+    lintToken: (token) ->
         [type, value, lineNumber] = token
 
         if typeof lineNumber is "object"
@@ -66,7 +66,7 @@ module.exports = class LexicalLinter extends BaseLinter
             errors.push v if v?
         errors
 
-    createError : (ruleName, attrs = {}) ->
+    createError: (ruleName, attrs = {}) ->
         attrs.lineNumber = @lineNumber + 1
         attrs.line = @tokenApi.lines[@lineNumber]
         super ruleName, attrs

--- a/src/rules/no_implicit_parens.coffee
+++ b/src/rules/no_implicit_parens.coffee
@@ -20,7 +20,7 @@ module.exports = class NoImplicitParens
             """
 
 
-    tokens: [ 'CALL_END' ]
+    tokens: ['CALL_END']
 
     lintToken : (token, tokenApi) ->
         if token.generated

--- a/test/test_no_implicit_braces.coffee
+++ b/test/test_no_implicit_braces.coffee
@@ -3,7 +3,7 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-vows.describe('braces').addBatch({
+vows.describe('no_implicit_braces').addBatch({
 
     'Implicit braces' :
 
@@ -49,7 +49,7 @@ vows.describe('braces').addBatch({
         "allows braces at the end of lines when strict is false": (source) ->
             config =
                 no_implicit_braces :
-                    level:'error'
+                    level: 'error'
                     strict: false
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
@@ -87,5 +87,61 @@ vows.describe('braces').addBatch({
             errors = coffeelint.lint(source)
             assert.isArray(errors)
             assert.isEmpty(errors)
+
+    'Test that any implicit braces inside classes are caught':
+        topic: () ->
+            """
+            class ABC
+              @CONST = 'DEF'
+
+              constructor: (abc) ->
+                s =
+                  t: 3
+
+              getDef: ->
+                u =
+                  v: 'a'
+
+            class A extends B
+              @PI = 3
+
+              constructor: ->
+                @a = 3
+
+            class Role extends Model
+              @A = '1'
+              @B = []
+              @C = 3
+              @D = {}
+
+              constructor: (x) ->
+                x = 5
+                @E = 3
+
+              eFunc: (f, g) ->
+                g = @B * f
+                return [@A, g]
+
+            """
+
+        'throws no errors for this when strict is false': (source) ->
+            config =
+                no_implicit_braces:
+                    level: 'error'
+                    strict: false
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 0)
+
+        'throws 2 errors for this when strict is true': (source) ->
+            config =
+                no_implicit_braces:
+                    level: 'error'
+                    strict: true
+            errors = coffeelint.lint(source, config)
+            assert.isArray(errors)
+            assert.lengthOf(errors, 2)
+            assert.equal(errors[0].lineNumber, 6)
+            assert.equal(errors[1].lineNumber, 10)
 
 }).export(module)


### PR DESCRIPTION
This was caused because class declarations generate a brace so this
changes it to ignore the first implied brace, but take into account any
future implied braces

Fixes #324

Renamed test_braces.coffee to test_no_implicit_braces.coffee