### PR TITLE
Work around a require issue with atom

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -17,13 +17,18 @@ nodeRequire = require
 if window?
     # If we're in the browser assume CoffeeScript is already loaded.
     CoffeeScript = window.CoffeeScript
-else
-    # By using nodeRequire it prevents browserify from finding this dependency.
-    # If it isn't hidden there is an error attempting to inline CoffeeScript.
-    # if browserify uses `-i` to ignore the dependency it creates an empty shim
-    # which breaks NodeJS
-    # https://github.com/substack/node-browserify/issues/471
-    CoffeeScript = nodeRequire 'coffee-script'
+# By using nodeRequire it prevents browserify from finding this dependency.
+# If it isn't hidden there is an error attempting to inline CoffeeScript.
+# if browserify uses `-i` to ignore the dependency it creates an empty shim
+# which breaks NodeJS
+# https://github.com/substack/node-browserify/issues/471
+#
+# Atom has a `window`, but not a `window.CoffeeScript`. Calling `nodeRequire`
+# here should fix Atom wihtout breaking anything else.
+CoffeeScript ?= nodeRequire 'coffee-script'
+
+unless CoffeeScript?
+    throw new Error('Unable to find CoffeeScript')
 
 # Browserify will inline the file at compile time.
 packageJSON = require('./../package.json')

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -24,7 +24,7 @@ if window?
 # https://github.com/substack/node-browserify/issues/471
 #
 # Atom has a `window`, but not a `window.CoffeeScript`. Calling `nodeRequire`
-# here should fix Atom wihtout breaking anything else.
+# here should fix Atom without breaking anything else.
 CoffeeScript ?= nodeRequire 'coffee-script'
 
 unless CoffeeScript?


### PR DESCRIPTION
I'm preparing to submit a PR to [linter-coffeelint](https://github.com/AtomLinter/linter-coffeelint) to get it to require CoffeeLint directly instead of calling the CLI and regexing the values out of that output. Atom has a `window` variable, so the current behavior assumes that it's in a browser and that node isn't available.