### PR TITLE
Add allow_empty boolean to braces_spacing when spaces is 1 for {}

### DIFF
--- a/src/rules/braces_spacing.coffee
+++ b/src/rules/braces_spacing.coffee
@@ -15,6 +15,8 @@ module.exports = class BracesSpacing
             {a: b }    # Bad
             { a: b}    # Bad
             { a: b }   # Bad
+            {}         # Good
+            { }        # Bad
 
             # Spaces is 1
             {a: b}     # Bad
@@ -24,6 +26,12 @@ module.exports = class BracesSpacing
             { a: b  }  # Bad
             {  a: b }  # Bad
             {  a: b  } # Bad
+            {}         # Bad
+            { }        # Good
+
+            # Spaces is 1 and Allow Empty is true
+            {}         # Good
+            { }        # Good
             </code></pre>
 
             This rule is disabled by default.
@@ -57,8 +65,9 @@ module.exports = class BracesSpacing
 
         expected = tokenApi.config[@rule.name].spaces
         actual = @distanceBetweenTokens firstToken, secondToken
+        allowEmpty = expected is 1 and tokenApi.config[@rule.name].allow_empty
 
-        if actual is expected
+        if actual is expected or allowEmpty and actual is 0
             null
         else
             msg = "There should be #{expected} space"

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -36,6 +36,8 @@ configs =
         braces_spacing: {level: 'error', spaces: 0}
     oneSpace:
         braces_spacing: {level: 'error', spaces: 1}
+    oneSpaceAllowEmtpy:
+        braces_spacing: {level: 'error', spaces: 1, allow_empty: true}
 
 shouldPass = (source, config = {}) ->
     topic: coffeelint.lint(source, config)
@@ -154,6 +156,30 @@ vows.describe('braces_spacing').addBatch({
             'one space inside on both braces':
                 shouldPass(sources.stringInterpolation.oneSpace,
                            configs.oneSpace)
+
+
+    'enabled with spaces set to 1 and allow_empty set to true' :
+        'braces on the line':
+            'no spaces inside both braces':
+                shouldPass(sources.sameLine.noSpaces,
+                           configs.oneSpaceAllowEmtpy)
+
+            'two spaces inside on both braces':
+                shouldFail(sources.sameLine.twoSpaces,
+                           configs.oneSpaceAllowEmtpy,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
+
+        'braces on separate lines':
+            'no spaces inside both braces':
+                shouldPass(sources.sameLine.noSpaces,
+                           configs.oneSpaceAllowEmtpy)
+
+            'two spaces inside on both braces':
+                shouldFail(sources.splitLine.twoSpaces,
+                           configs.oneSpaceAllowEmtpy,
+                           ['There should be 1 space inside "{"',
+                            'There should be 1 space inside "}"'])
 
 
 }).export(module)


### PR DESCRIPTION
I would like `{}` to be valid even when I've set braces_spacing `spaces` to 1. Since there was a test against this, I decided to add a configuration option (`allow_empty`). I would also be fine with allowing both `{ }` and `{}` by default (when `spaces` is 1). Thoughts?