### PR TITLE
missing_fat_arrows: enable checking class methods

### DIFF
--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -18,9 +18,7 @@ module.exports = class MissingFatArrows
         message: 'Used `this` in a function without a fat arrow'
         description: """
             Warns when you use `this` inside a function that wasn't defined
-            with a fat arrow. This rule does not apply to methods defined in a
-            class, since they have `this` bound to the class instance (or the
-            class itself, for class methods).
+            with a fat arrow.
 
             It is impossible to statically determine whether a function using
             `this` will be bound with the correct `this` value due to language
@@ -34,8 +32,6 @@ module.exports = class MissingFatArrows
 
     lintNode: (node, methods = []) ->
         if (not @isFatArrowCode node) and
-                # Ignore any nodes we know to be methods
-                (node not in methods) and
                 (@needsFatArrow node)
             error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1
@@ -74,4 +70,3 @@ module.exports = class MissingFatArrows
                 .map((assignNode) -> assignNode.value)
                 .filter(@isCode)
         else []
-

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -66,7 +66,7 @@ vows.describe(RULE).addBatch({
             class A
                 @m: -> 1
             """
-        'with this': shouldPass """
+        'with this': shouldError """
             class A
                 @m: -> this
             """
@@ -76,7 +76,7 @@ vows.describe(RULE).addBatch({
             class A
                 m: -> 1
             """
-        'with this': shouldPass """
+        'with this': shouldError """
             class A
                 m: -> this
             """
@@ -107,10 +107,10 @@ vows.describe(RULE).addBatch({
         'with this': shouldPass """
             class A
                 f = => this
-                m: -> this
-                @n: -> this
-                o: -> this
-                @p: -> this
+                m: => this
+                @n: => this
+                o: => this
+                @p: => this
             """
 
     'https://github.com/clutchski/coffeelint/issues/215':


### PR DESCRIPTION
Rule description mentions that class methods and class instance methods have `this` auto-bound. This doesn't seem to be true.

```coffee
class Animal
  constructor: (@roar) -> null
  getRoar: -> @roar
  @planet: 'earth'
  @getPlanet: -> @planet

cat = new Animal('rawr')
cat.getRoar() # 'rawr'
catRoar = cat.getRoar
catRoar() # 'undefined'
Animal.getPlanet() # 'earth'
animalGetPlanet = Animal.getPlanet
animalGetPlanet() # 'undefined'

# vs

class Animal
  constructor: (@roar) -> null
  getRoar: => @roar
  @planet: 'earth'
  @getPlanet: => @planet

cat = new Animal('rawr')
cat.getRoar() # 'rawr'
catRoar = cat.getRoar
catRoar() # 'rawr'
Animal.getPlanet() # 'earth'
animalGetPlanet = Animal.getPlanet
animalGetPlanet() # 'undefined'
```