### PR TITLE
Avoid non-standard String.prototype.trimRight

### DIFF
--- a/src/rules/max_line_length.coffee
+++ b/src/rules/max_line_length.coffee
@@ -31,7 +31,7 @@ module.exports = class MaxLineLength
         max = lineApi.config[@rule.name]?.value
         limitComments = lineApi.config[@rule.name]?.limitComments
 
-        lineLength = line.trimRight().length
+        lineLength = line.replace(/\s+$/, '').length
         if lineApi.isLiterate() and regexes.literateComment.test(line)
             lineLength -= 2
 


### PR DESCRIPTION
While `String.prototype.trim` is part of the ES spec, `trimRight` and `trimLeft` aren't.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight

This improves compatibly running the `MaxLineLength` linter in browsers that may not support `trimRight`.