### PR TITLE
Add link to overcommit

### DIFF
--- a/index-bottom.html
+++ b/index-bottom.html
@@ -176,6 +176,11 @@
                 <a href="https://github.com/zipcodeman/coffeelint-ruby">coffeelint-ruby</a>
                 is a set of bindings for ruby, by Zachary Bush
               </li>
+              <li>
+                <a href="https://github.com/brigade/overcommit">overcommit</a>
+                is a fully configurable and extendable Git hook manager
+                including support for CoffeeLint.
+              </li>
             </ul>
           </p>
 

--- a/index.html
+++ b/index.html
@@ -803,6 +803,11 @@ and warns that line numbers are probably incorrect.
                 <a href="https://github.com/zipcodeman/coffeelint-ruby">coffeelint-ruby</a>
                 is a set of bindings for ruby, by Zachary Bush
               </li>
+              <li>
+                <a href="https://github.com/brigade/overcommit">overcommit</a>
+                is a fully configurable and extendable Git hook manager
+                including support for CoffeeLint.
+              </li>
             </ul>
           </p>
 


### PR DESCRIPTION
overcommit is a fully configurable and extendable Git hook manager that
includes out-of-the-box support for CoffeeLint.