### PR TITLE
Fix for issue #412

### DIFF
--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -62,7 +62,7 @@ module.exports = class MissingFatArrows
     isObject: (node) => @astApi.getNodeName(node) is 'Obj'
     isThis: (node) => @isValue(node) and node.base.value is 'this'
     isFatArrowCode: (node) => @isCode(node) and node.bound
-    isConstructor: (node) -> node.variable?.base.value is 'constructor'
+    isConstructor: (node) -> node.variable?.base?.value is 'constructor'
 
 
 


### PR DESCRIPTION
This particular line was throwing a reference error on invoking the missing fat arrows rule. The reason is that not all node.variable have a base property (another way to be to call @isCode, but perhaps this is faster?).