### PR TITLE
spacing_after_comma: Ignore comma in generated REGEXP calls.

### DIFF
--- a/src/rules/spacing_after_comma.coffee
+++ b/src/rules/spacing_after_comma.coffee
@@ -6,6 +6,30 @@ module.exports = class RuleProcessor
         level: 'ignore'
         message: 'Spaces are required after commas'
 
-    tokens: [',']
+    tokens: [',', 'REGEX_START', 'REGEX_END']
+
+    constructor: ->
+        @inRegex = false
+
     lintToken: (token, tokenApi) ->
-        {context : token[1]} unless token.spaced or token.newLine
+        [ type ] = token
+
+        if type is 'REGEX_START'
+            @inRegex = true
+            return
+        if type is 'REGEX_END'
+            @inRegex = false
+            return
+
+        unless token.spaced or token.newLine or token.generated or
+                @isRegexFlag(token, tokenApi)
+            {context : token[1]}
+
+    # When generating a regex (///${whatever}///i) CoffeeScript generates tokens
+    # for RegEx(whatever, "i") but doesn't bother to mark that comma as
+    # generated or spaced. Looking 3 tokens ahead skips the STRING and CALL_END
+    isRegexFlag: (token, tokenApi) ->
+        return false unless @inRegex
+
+        maybeEnd = tokenApi.peek(3)
+        return maybeEnd?[0] is 'REGEX_END'

--- a/test/test_spacing_after_comma.coffee
+++ b/test/test_spacing_after_comma.coffee
@@ -5,6 +5,17 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 vows.describe('commas').addBatch({
 
+    'regex':
+        topic: '''
+        ///^#{ inputValue }///i.test field.name
+        '''
+
+        'should not error': (source) ->
+            config = {spacing_after_comma : {level:'warn'}}
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+
     'Whitespace after commas' :
 
         topic : () ->


### PR DESCRIPTION
Fixes #420 