### PR TITLE
Add an option to no_debugger to catch console calls

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,4 +1,8 @@
 {
+    "no_debugger": {
+        "level": "error",
+        "console": true
+    },
     "arrow_spacing": {
         "level": "error"
     },

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -232,7 +232,6 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
                 },
                 config.transform_messes_up_line_numbers
             ))
-            console.log errors
 
     if userConfig?.coffeelint?.coffeescript?
         CoffeeScript = ruleLoader.require userConfig.coffeelint.coffeescript

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -22,6 +22,11 @@ Cache = require(path.join(thisdir, "cache"))
 CoffeeScript = require 'coffee-script'
 CoffeeScript.register()
 
+log = ->
+    # coffeelint: disable=no_debugger
+    console.log(arguments...)
+    # coffeelint: enable=no_debugger
+
 # Return the contents of the given file synchronously.
 read = (path) ->
     realPath = fs.realpathSync(path)
@@ -172,13 +177,13 @@ options = optimist
             .boolean("c")
 
 if options.argv.v
-    console.log coffeelint.VERSION
+    log coffeelint.VERSION
     process.exit(0)
 else if options.argv.h
     options.showHelp()
     process.exit(0)
 else if options.argv.makeconfig
-    console.log JSON.stringify coffeelint.getRules(),
+    log JSON.stringify coffeelint.getRules(),
         ((k,v) -> v unless k in ['message', 'description', 'name']), 4
 else if options.argv._.length < 1 and not options.argv.s
     options.showHelp()

--- a/src/htmldoc.coffee
+++ b/src/htmldoc.coffee
@@ -8,7 +8,9 @@ render = () ->
         rule = rules[ruleName]
         rule.name = ruleName
         rule.description = "[no description provided]" unless rule.description
+        # coffeelint: disable=no_debugger
         console.log ruleTemplate rule
+        # coffeelint: enable=no_debugger
 
 ruleTemplate = _.template """
     <tr>

--- a/src/reporters/checkstyle.coffee
+++ b/src/reporters/checkstyle.coffee
@@ -6,7 +6,9 @@ module.exports = class CheckstyleReporter
     constructor : (@errorReport, options = {}) ->
 
     print : (message) ->
+        # coffeelint: disable=no_debugger
         console.log message
+        # coffeelint: enable=no_debugger
 
     escape : JsLintReporter::escape
 

--- a/src/reporters/csv.coffee
+++ b/src/reporters/csv.coffee
@@ -3,7 +3,9 @@ module.exports = class CSVReporter
     constructor : (@errorReport, options = {}) ->
 
     print : (message) ->
+        # coffeelint: disable=no_debugger
         console.log message
+        # coffeelint: enable=no_debugger
 
     publish : () ->
         header = ["path","lineNumber", "lineNumberEnd", "level", "message"]

--- a/src/reporters/default.coffee
+++ b/src/reporters/default.coffee
@@ -77,8 +77,9 @@ module.exports = class Reporter
         pathReport
 
     print : (message) ->
+        # coffeelint: disable=no_debugger
         console.log message
+        # coffeelint: enable=no_debugger
 
     plural : (str, count) ->
         if count is 1 then str else "#{str}s"
-

--- a/src/reporters/jslint.coffee
+++ b/src/reporters/jslint.coffee
@@ -3,7 +3,9 @@ module.exports = class JSLintReporter
     constructor : (@errorReport, options = {}) ->
 
     print : (message) ->
+        # coffeelint: disable=no_debugger
         console.log message
+        # coffeelint: enable=no_debugger
 
     publish : () ->
         @print "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint>"

--- a/src/reporters/raw.coffee
+++ b/src/reporters/raw.coffee
@@ -3,8 +3,9 @@ module.exports = class RawReporter
     constructor : (@errorReport, options = {}) ->
 
     print : (message) ->
+        # coffeelint: disable=no_debugger
         console.log message
+        # coffeelint: enable=no_debugger
 
     publish : () ->
         @print JSON.stringify(@errorReport.paths, undefined, 2)
-

--- a/src/ruleLoader.coffee
+++ b/src/ruleLoader.coffee
@@ -44,5 +44,7 @@ module.exports =
                 for rule in ruleModule
                     coffeelint.registerRule rule
         catch e
+            # coffeelint: disable=no_debugger
             console.error "Error loading #{moduleName}"
             throw e
+            # coffeelint: enable=no_debugger

--- a/src/rules/no_debugger.coffee
+++ b/src/rules/no_debugger.coffee
@@ -4,13 +4,20 @@ module.exports = class NoDebugger
     rule:
         name: 'no_debugger'
         level : 'warn'
-        message : 'Debugger statements will cause warnings'
+        message : 'Found debugging code'
+        console: false
         description: """
-            This rule detects the `debugger` statement.
+            This rule detects `debugger` and optionally `console` calls
             This rule is `warn` by default.
             """
 
-    tokens: [ "DEBUGGER" ]
+    tokens: [ "DEBUGGER", "IDENTIFIER" ]
 
     lintToken : (token, tokenApi) ->
-        return {context : "found '#{token[0]}'"}
+        if token[0] is 'DEBUGGER'
+            return {context : "found '#{token[0]}'"}
+
+        if tokenApi.config[@rule.name]?.console
+            if token[1] is 'console' and tokenApi.peek(1)?[0] is '.'
+                method = tokenApi.peek(2)
+                return {context : "found 'console.#{method[1]}'"}

--- a/test/test_debugger.coffee
+++ b/test/test_debugger.coffee
@@ -6,6 +6,20 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 vows.describe('no_debugger').addBatch({
 
+    'console calls':
+        topic: '''
+        console.log("hello world")
+        '''
+
+        'causes a warning when present' : (source) ->
+            errors = coffeelint.lint(source, {
+                no_debugger:
+                    'level':'error'
+                    "console": true
+            })
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+
     'The debugger statement' :
 
         topic : ->
@@ -21,7 +35,7 @@ vows.describe('no_debugger').addBatch({
             assert.equal(error.level, 'warn')
             assert.equal(error.lineNumber, 1)
             assert.equal(error.rule, 'no_debugger')
-            
+
         'can be set to error' : (source) ->
             errors = coffeelint.lint(source, {no_debugger: {'level':'error'}})
             assert.isArray(errors)


### PR DESCRIPTION
For backward compatibility this does not warn about `console` calls by default

How to enable in your coffeelint.json

    "no_debugger": {
        "level": "error",
        "console": true
    },

How to allow a console call:

```CoffeeScript
# coffeelint: disable=no_debugger
console.log(whatever)
# coffeelint: enable=no_debugger
```

Fixes #416 
Fixes #411 