### PR TITLE
Added no_private_function_fat_arrows rule

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -174,6 +174,7 @@ coffeelint.registerRule(
 coffeelint.registerRule require './rules/ensure_comprehensions.coffee'
 coffeelint.registerRule require './rules/no_this.coffee'
 coffeelint.registerRule require './rules/eol_last.coffee'
+coffeelint.registerRule require './rules/no_private_function_fat_arrows.coffee'
 
 hasSyntaxError = (source) ->
     try

--- a/src/rules/no_private_function_fat_arrows.coffee
+++ b/src/rules/no_private_function_fat_arrows.coffee
@@ -1,0 +1,44 @@
+
+module.exports = class NoPrivateFunctionFatArrows
+
+    rule:
+        name: 'no_private_function_fat_arrows'
+        level: 'warn'
+        message: 'Used the fat arrow for a private function'
+        description: """
+            Warns when you use the fat arrow for an object method. This is
+            useful for the code style where caller is expected to assure calls
+            of object methods are bound with the correct `this` value.
+            """
+
+    lintAST: (node, @astApi) ->
+        @lintNode node
+        undefined
+
+    lintNode: (node, functions = []) ->
+        if @isFatArrowCode(node) and node in functions
+            error = @astApi.createError
+                lineNumber: node.locationData.first_line + 1
+            @errors.push error
+
+        node.eachChild (child) => @lintNode child,
+            switch
+                when @isClass node then @functionsOfClass node
+                # Once we've hit a function, we know we can't be in the top
+                # level of a function anymore, so we can safely reset the
+                # functions to empty to save work.
+                when @isCode node then []
+                else functions
+
+    isCode: (node) => @astApi.getNodeName(node) is 'Code'
+    isClass: (node) => @astApi.getNodeName(node) is 'Class'
+    isValue: (node) => @astApi.getNodeName(node) is 'Value'
+    isObject: (node) => @astApi.getNodeName(node) is 'Obj'
+    isFatArrowCode: (node) => @isCode(node) and node.bound
+
+    functionsOfClass: (classNode) ->
+        bodyValues = for bodyNode in classNode.body.expressions
+            continue if @isValue(bodyNode) and @isObject(bodyNode.base)
+
+            bodyNode.value
+        bodyValues.filter(@isCode)

--- a/src/rules/no_private_function_fat_arrows.coffee
+++ b/src/rules/no_private_function_fat_arrows.coffee
@@ -6,9 +6,9 @@ module.exports = class NoPrivateFunctionFatArrows
         level: 'warn'
         message: 'Used the fat arrow for a private function'
         description: """
-            Warns when you use the fat arrow for an object method. This is
-            useful for the code style where caller is expected to assure calls
-            of object methods are bound with the correct `this` value.
+            Warns when you use the fat arrow for a private function
+            inside a class defintion scope. It is not necessary and
+            it does not do anything.
             """
 
     lintAST: (node, @astApi) ->

--- a/test/test_no_private_function_fat_arrows.coffee
+++ b/test/test_no_private_function_fat_arrows.coffee
@@ -1,0 +1,51 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+config = {
+    no_unnecessary_fat_arrows: {level: 'ignore'}
+    no_private_function_fat_arrows: {level: 'error'}
+}
+
+vows.describe('no_private_function_fat_arrows').addBatch({
+
+    'eol':
+        'should warn with fat arrow': ->
+            result = coffeelint.lint("""
+            class Foo
+              foo = =>
+            """, config)
+            assert.equal(result.length, 1)
+            assert.equal(result[0].rule,  'no_private_function_fat_arrows')
+            assert.equal(result[0].level, 'error')
+
+        'should work with nested classes': ->
+            result = coffeelint.lint("""
+            class Bar
+              foo = ->
+                class
+                  bar2 = =>
+            """, config)
+            assert.equal(result.length, 1)
+            assert.equal(result[0].rule,  'no_private_function_fat_arrows')
+            assert.equal(result[0].level, 'error')
+
+            # Same method name as external function.
+            result = coffeelint.lint("""
+            class Bar
+              foo = ->
+                class
+                  foo = =>
+            """, config)
+            assert.equal(result.length, 1)
+            assert.equal(result[0].rule,  'no_private_function_fat_arrows')
+            assert.equal(result[0].level, 'error')
+
+        'should not warn without fat arrow': ->
+            assert.isEmpty(coffeelint.lint("""
+            class Foo
+              foo = ->
+            """, config))
+
+}).export(module)


### PR DESCRIPTION
I set it to warn, because this is clearly a mistake. We could also even make it an error.

This makes linting complain aobut:

```coffee
class Foo
  foo = =>
```

It should be:

```coffee
class Foo
  foo = ->
```

And CoffeeScript produces the same code in both cases.