### PR TITLE
Document newlines_after_classes config option

### DIFF
--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -10,7 +10,8 @@ module.exports = class NewlinesAfterClasses
         <p>Checks the number of newlines between classes and other code.</p>
         
         Options:
-        - <pre><code>value</code></pre> - The number of required newlines after class definitions. Defaults to 3.
+        - <pre><code>value</code></pre> - The number of required newlines
+        after class definitions. Defaults to 3.
         """
 
     lintLine: (line, lineApi) ->

--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -10,7 +10,7 @@ module.exports = class NewlinesAfterClasses
         <p>Checks the number of newlines between classes and other code.</p>
         
         Options:
-        - <pre><code>`value`</code></pre> - The number of required newlines after class definitions. Defaults to 3.
+        - <pre><code>value</code></pre> - The number of required newlines after class definitions. Defaults to 3.
         """
 
     lintLine: (line, lineApi) ->

--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -6,8 +6,12 @@ module.exports = class NewlinesAfterClasses
         value : 3
         level : 'ignore'
         message : 'Wrong count of newlines between a class and other code'
-        description: "Checks the number of newlines between classes and other
-        code"
+        description: """
+        <p>Checks the number of newlines between classes and other code.</p>
+        
+        Options:
+        - <pre><code>`value`</code></pre> - The number of required newlines after class definitions. Defaults to 3.
+        """
 
     lintLine: (line, lineApi) ->
         ending = lineApi.config[@rule.name].value


### PR DESCRIPTION
This documents the `value` option for the `newlines_after_classes` rule – I had no idea it was configurable till I looked at the source.

Refs https://github.com/atom/atom/pull/6898#discussion_r30926627