### PR TITLE
Add --ext CLI option to include additional file extension

### DIFF
--- a/test/fixtures/custom_extention/clean.csbx
+++ b/test/fixtures/custom_extention/clean.csbx
@@ -1,0 +1,6 @@
+###
+A lint free script.
+###
+
+x = () ->
+  return 1234 + 4567

--- a/test/test_commandline.coffee
+++ b/test/test_commandline.coffee
@@ -372,6 +372,36 @@ vows.describe('commandline').addBatch({
                 assert.isNotNull(error)
                 assert.include(stdout.toLowerCase(), 'trailing whitespace')
 
+    'additional file extention':
+
+        'find additional files with --ext key':
+            topic: () ->
+                args = [
+                    '--ext',
+                    'csbx',
+                    'fixtures/custom_extention'
+                    ]
+                commandline args, this.callback
+                return undefined
+
+            'passes': (error, stdout, stderr) ->
+                assert.isNull(error)
+                assert.isEmpty(stderr)
+                assert.isString(stdout)
+                assert.include(stdout, '0 errors and 0 warnings in 1 file')
+
+        'do not find additional files without --ext key':
+            topic: () ->
+                args = ['fixtures/custom_extention']
+                commandline args, this.callback
+                return undefined
+
+            'fails': (error, stdout, stderr) ->
+                assert.isNull(error)
+                assert.isEmpty(stderr)
+                assert.isString(stdout)
+                assert.include(stdout, '0 errors and 0 warnings in 0 file')
+
     'using environment config file':
 
         'with non existing enviroment set config file':


### PR DESCRIPTION
Add '--ext' CLI option to include additional file extension, fe
`$coffeelint --ext csbx ./testdir/`
will check '.coffee' and '.csbx' files.
Extension may be listed by comma
`$coffeelint --ext csbx,myext,myext2 ./testdir/`

Why - we are use custom CoffeeScript file extention '.csbx' - its coffee with React inserts in backtricks and custom builder for result js file. Extention used as flag for different processors and save a lot of time, excluding unnecessary React processor step for pure coffee files. 
So, we are need custom filenames in `coffeelint`