### PR TITLE
arrow_spacing: fixes crash at beginning of line

### DIFF
--- a/src/rules/arrow_spacing.coffee
+++ b/src/rules/arrow_spacing.coffee
@@ -40,8 +40,12 @@ module.exports = class ArrowSpacing
         # e.g. (-> true)()
         #
         # we will accept either having a space or not having a space there.
+        #
+        # Also if the -> is the beginning of the file, then simply just return
 
         pp = tokenApi.peek(-1)
+
+        return unless pp
 
         if not token.spaced and
                 (pp[1] is "(" and not pp.generated?) and
@@ -60,7 +64,7 @@ module.exports = class ArrowSpacing
 
     # Are there any more meaningful tokens following the current one?
     atEof: (tokenApi) ->
-        {tokens, i } = tokenApi
+        { tokens, i } = tokenApi
         for token in tokens.slice(i + 1)
             unless token.generated or token[0] in ['OUTDENT', 'TERMINATOR']
                 return false

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -227,4 +227,18 @@ vows.describe('arrows').addBatch({
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
+    'Handle an arrow at beginning of file' :
+        topic : ->
+            '-> foo()'
+
+        'when spacing is required around arrow operator' : (source) ->
+            config = { "arrow_spacing": { "level": "error" } }
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'when spacing is not required around arrow operator' : (source) ->
+            config = { "arrow_spacing": { "level": "ignore" } }
+            errors = coffeelint.lint(source, config)
+            assert.isEmpty(errors, 0)
+
 }).export(module)


### PR DESCRIPTION
This fixes a crash if an arrow is the very beginning of a file, thus
having no previous tokens.

Fixes #481