### PR TITLE
Add missing_parseint_radix rule

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -220,6 +220,7 @@ coffeelint.registerRule require './rules/ensure_comprehensions.coffee'
 coffeelint.registerRule require './rules/no_this.coffee'
 coffeelint.registerRule require './rules/eol_last.coffee'
 coffeelint.registerRule require './rules/no_private_function_fat_arrows.coffee'
+coffeelint.registerRule require './rules/missing_parseint_radix.coffee'
 
 hasSyntaxError = (source) ->
     try

--- a/src/rules/missing_parseint_radix.coffee
+++ b/src/rules/missing_parseint_radix.coffee
@@ -1,0 +1,30 @@
+module.exports = class ParseintRadix
+
+    rule:
+        name: 'missing_parseint_radix'
+        level : 'warn'
+        message : 'parseInt is missing the radix argument'
+        description: """
+            This rule warns about using parseInt without a radix. From the MDN
+            developers reference: <q>Always specify this parameter to eliminate
+            reader confusion and to guarantee predictable behavior.</q>
+            <pre>
+              <code># You would expect this to result in 8, but
+              # it might result in 0 (parsed as octal).
+              parseInt '08'
+
+              # To be safe, specify the radix argument:
+              parseInt '08', 10
+              </code>
+            </pre>
+            """
+
+
+    tokens: ['CALL_START']
+
+    lintToken : (token, tokenApi) ->
+        [prevToken, functionName] = tokenApi.peek(-1)
+
+        if functionName is 'parseInt'
+            [callEnd] = tokenApi.peek(2)
+            return callEnd is 'CALL_END'

--- a/test/test_missing_parseint_radix.coffee
+++ b/test/test_missing_parseint_radix.coffee
@@ -1,0 +1,58 @@
+path = require 'path'
+vows = require 'vows'
+assert = require 'assert'
+coffeelint = require path.join('..', 'lib', 'coffeelint')
+
+vows.describe('missing_parseint_radix').addBatch({
+
+    'parseInt without radix':
+        topic : "parseInt '08'"
+
+        'should warn by default' : (source) ->
+            errors = coffeelint.lint(source)
+            {lineNumber, message, rule, level} = errors[0]
+
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+            assert.equal(lineNumber, 1)
+            assert.equal(message, 'parseInt is missing the radix argument')
+            assert.equal(rule, 'missing_parseint_radix')
+            assert.equal(level, 'warn')
+
+        'can be forbidden' : (source) ->
+            config = {missing_parseint_radix : {level:'error'}}
+            errors = coffeelint.lint(source, config)
+            {lineNumber, message, rule, level} = errors[0]
+
+            assert.isArray(errors)
+            assert.lengthOf(errors, 1)
+            assert.equal(lineNumber, 1)
+            assert.equal(message, 'parseInt is missing the radix argument')
+            assert.equal(rule, 'missing_parseint_radix')
+            assert.equal(level, 'error')
+
+        'can be permitted' : (source) ->
+            config = {missing_parseint_radix : {level:'ignore'}}
+            errors = coffeelint.lint(source, config)
+
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+    'parseInt with radix':
+        topic : "parseInt '08', 10"
+
+        'should not cause a warning' : (source) ->
+            errors = coffeelint.lint(source)
+
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+        'should not cause an error' : (source) ->
+            config = {missing_parseint_radix : {level:'error'}}
+            errors = coffeelint.lint(source, config)
+
+            assert.isArray(errors)
+            assert.isEmpty(errors)
+
+}).export(module)
+


### PR DESCRIPTION
Our QA team found a bug in IE8 caused by a `parseInt` without the radix argument, which unfortunately fell through our code review. It would be great to have a coffeelint rule for this. 

In JSHint, there's no explicit rule for a missing radix argument, but there's a [ES3 flag](https://jslinterrors.com/option-jshint-es3). It seems to me that most of the ES3 errors are already mitigated by the CoffeeScript transpiler (extra commas, get/set, reserved keywords, etc). That's why I think an explicit `missing_parseint_radix` rule seems reasonable, instead of a broader "ES3" rule.

I set the default level to `warn`. I personally think it makes sense, and it's recommended in the [MDN developers reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) to always specify the radix argument. I would be ok with `ignore` as well, if you think a warning is too invasive.
