### PR TITLE
braces_spacing: ignore generated tokens on same line

### DIFF
--- a/src/rules/braces_spacing.coffee
+++ b/src/rules/braces_spacing.coffee
@@ -47,10 +47,10 @@ module.exports = class BracesSpacing
 
     findNearestToken: (token, tokenApi, difference) ->
         totalDifference = 0
-        while true
+        loop
             totalDifference += difference
             nearestToken = tokenApi.peek(totalDifference)
-            continue if nearestToken[0] is 'OUTDENT'
+            continue if nearestToken[0] is 'OUTDENT' or nearestToken.generated?
             return nearestToken
 
     tokensOnSameLine: (firstToken, secondToken) ->

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -35,6 +35,18 @@ sources =
         noSpaces: "\"\#{foo}\""
         oneSpace: "\"\#{ foo }\""
 
+    fnImplicitParens:
+        '''
+        [
+          {
+            foo: ->
+              bar ->
+                1
+          }
+        ]
+        '''
+
+
 configs =
     oneEmptyObjectSpace:
         braces_spacing: {level: 'error', empty_object_spaces: 1}
@@ -199,5 +211,13 @@ vows.describe('braces_spacing').addBatch({
                        ['There should be 1 space inside "{"',
                         'There should be 1 space inside "}"'])
 
+    'handles generated tokens being on the same line (in outputted code)':
+        'no spaces inside both braces':
+            shouldPass(sources.fnImplicitParens,
+                       configs.zeroSpaces)
+
+        'should pass with one space on both braces':
+            shouldPass(sources.fnImplicitParens,
+                       configs.oneSpace)
 
 }).export(module)


### PR DESCRIPTION
This fixes problems where a generated token interferes with the check to
make sure the token after the brace token ('{' or '}') is on the same
line. If it is a generated token, then it means that the user did not
actually type in that token.

Fixes #489