### PR TITLE
Fix several issues related to indentation

### DIFF
--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -1,4 +1,3 @@
-
 module.exports = class Indentation
 
     rule:
@@ -44,7 +43,7 @@ module.exports = class Indentation
 
             currentLine = lines[lineNumber]
 
-            if currentLine.match(/\S/i)?[0] is '.'
+            if currentLine.match(/\S/)?[0] is '.'
                 return @handleChain(tokenApi, expected)
             return undefined
 
@@ -131,9 +130,9 @@ module.exports = class Indentation
             # If this is just a one-chain function, or the "corrected"
             # previous line begins with a '.', check for correct
             # indentation
-            if prevLine.match(/\S/i)[0] is '.' or checkNum is lastCheck
-                currentSpaces = currentLine.match(/\S/i)?.index
-                prevSpaces = prevLine.match(/\S/i)?.index
+            if prevLine.match(/\S/)[0] is '.' or checkNum is lastCheck
+                currentSpaces = currentLine.match(/\S/)?.index
+                prevSpaces = prevLine.match(/\S/)?.index
                 numIndents = currentSpaces - prevSpaces
 
                 # If both prev and current lines have uneven spacing,

--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -24,6 +24,13 @@ module.exports = class Indentation
 
     tokens: ['INDENT', '[', ']', '.']
 
+    keywords: [
+      '->', '=>', '@', 'CATCH', 'CLASS', 'ELSE', 'FINALLY', 'FOR',
+      'FORIN', 'FOROF', 'IDENTIFIER', 'IF', 'LEADING_WHEN', 'LOOP',
+      'RETURN', 'SWITCH', 'THROW', 'TRY', 'UNTIL', 'WHEN', 'WHILE',
+      'YIELD'
+    ]
+
     constructor: ->
         @arrayTokens = []   # A stack tracking the array token pairs.
 
@@ -82,8 +89,8 @@ module.exports = class Indentation
         numIndents = @getCorrectIndent(tokenApi)
 
         # Now check the indentation.
-        if not ignoreIndent and numIndents isnt expected
-            return { context: "Expected #{expected} got #{numIndents}" }
+        if not ignoreIndent and not (expected in numIndents)
+            return { context: "Expected #{expected} got #{numIndents[0]}" }
 
     # Return true if the current token is inside of an array.
     inArray: () ->
@@ -111,8 +118,10 @@ module.exports = class Indentation
         # Traverse up the token list until we see a CALL_START token.
         # Don't scan above this line
         findCallStart = tokenApi.peek(-callStart)
-        while (findCallStart and findCallStart[0] isnt 'TERMINATOR')
+        while (findCallStart and (findCallStart[0] isnt 'TERMINATOR' or
+                not findCallStart.newLine?))
             { first_line: lastCheck } = findCallStart[2]
+
             callStart += 1
             findCallStart = tokenApi.peek(-callStart)
 
@@ -147,20 +156,117 @@ module.exports = class Indentation
                 if numIndents % expected isnt 0
                     return { context: "Expected #{expected} got #{numIndents}" }
 
+    grabLineTokens: (tokenApi, lineNumber, all = false) ->
+        { tokensByLine } = tokenApi
+        lineNumber-- until tokensByLine[lineNumber]? or lineNumber is 0
+
+        if all
+            (tok for tok in tokensByLine[lineNumber])
+        else
+            (tok for tok in tokensByLine[lineNumber] when not
+                tok.generated? and tok[0] isnt 'OUTDENT')
+
     # Returns a corrected INDENT value if the current line is part of
     # a chained call. Otherwise returns original INDENT value.
     getCorrectIndent: (tokenApi) ->
-        { lineNumber, lines, tokens, i } = tokenApi
+        { lineNumber, lines, tokens } = tokenApi
 
         curIndent = lines[lineNumber].match(/\S/)?.index
 
         prevNum = 1
         prevNum += 1 while (/^\s*(#|$)/.test(lines[lineNumber - prevNum]))
 
-        prevLine = lines[lineNumber - prevNum]
-        prevIndent = prevLine.match(/^(\s*)\./)?[1].length
+        prevTokens = @grabLineTokens tokenApi, lineNumber - prevNum
 
-        if prevIndent > 0
-            return curIndent - prevLine.match(/\S/)?.index
+        if prevTokens[0]?[0] is 'INDENT'
+            # Pass both the INDENT value and the location of the first token
+            # after the INDENT because sometimes CoffeeScript doesn't return
+            # the correct INDENT if there is something like an if/else
+            # inside an if/else inside of a -> function definition: e.g.
+            #
+            # ->
+            #   r = if a
+            #     if b
+            #       2
+            #     else
+            #       3
+            #   else
+            #     4
+            #
+            # will error without: curIndent - prevTokens[1]?[2].first_column
+
+            return [curIndent - prevTokens[1]?[2].first_column,
+                curIndent - prevTokens[0][1]]
         else
-            return tokens[i][1]
+            prevIndent = prevTokens[0]?[2].first_column
+            # This is a scan to handle extra indentation from if/else
+            # statements to make them look nicer: e.g.
+            #
+            # r = if a
+            #   true
+            # else
+            #   false
+            #
+            # is valid.
+            #
+            # r = if a
+            #       true
+            #     else
+            #       false
+            #
+            # is also valid.
+            for _, j in prevTokens when prevTokens[j][0] is '=' and
+                    prevTokens[j + 1]?[0] is 'IF'
+                skipAssign = curIndent - prevTokens[j + 1][2].first_column
+                ret = curIndent - prevIndent
+                return [ret] if skipAssign < 0
+                return [skipAssign, ret]
+
+            # This happens when there is an extra indent to maintain long
+            # conditional statements (IF/UNLESS): e.g.
+            #
+            # ->
+            #   if a is c and
+            #     (false or
+            #       long.expression.that.necessitates(linebreak))
+            #     @foo()
+            #
+            # is valid (note that there an only an extra indent in the last
+            # statement is required and not the line above it
+            #
+            # ->
+            #   if a is c and
+            #       (false or
+            #       long.expression.that.necessitates(linebreak))
+            #     @foo()
+            # is also OK.
+            while prevIndent > curIndent
+                tryLine = lineNumber - prevNum
+                prevTokens = @grabLineTokens tokenApi, tryLine, true
+
+                # This is to handle weird object/string indentation.
+                # See: 'Handle edge-case weirdness with strings in objects'
+                #   test case in test_indentation.coffee or in the file,
+                #   test_no_empty_functions.coffee, which is why/how I
+                #   caught this.
+                if prevTokens[0]?[0] is 'INDENT'
+                    prevIndent = prevTokens[0][1]
+                    prevTokens = prevTokens[1..]
+
+                t = 0
+                # keep looping prevTokens until we find a token in @keywords
+                # or we just run out of tokens in prevTokens
+                until not prevTokens[t]? or prevTokens[t][0] in @keywords
+                    t++
+
+                # slice off everything before 't'
+                prevTokens = prevTokens[t..]
+                prevNum++
+
+                # if there isn't a valid token, restart the while loop
+                continue unless prevTokens[0]?
+
+                # set new "prevIndent"
+                prevIndent = prevTokens[0]?[2].first_column
+
+        return [curIndent - prevIndent]

--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -40,7 +40,6 @@ module.exports = class Indentation
             # Keep this if statement separately, since we still need to let
             # the linting pass if the '.' token is not at the beginning of
             # the line
-
             currentLine = lines[lineNumber]
 
             if currentLine.match(/\S/)?[0] is '.'

--- a/test/test_no_nested_string_interpolation.coffee
+++ b/test/test_no_nested_string_interpolation.coffee
@@ -39,7 +39,7 @@ vows.describe('no_nested_string_interpolation').addBatch({
             assert.isArray(errors)
             assert.isEmpty(errors)
 
-      'Deeply nested string interpolation' :
+    'Deeply nested string interpolation' :
 
         topic : '''
         str1 = "string #{"interpolation #{"inception"}"}"


### PR DESCRIPTION
This addresses several issues regarding indentation.

1. Being able to indent conditional if/else assignments to make them
look more pleasing.

Most users wanted to do something like this

```cs
y = if a
      true
    else
      false
```

This now won't return an error for the user.

Fixes #468
Fixes #345

_2. Fixed some bugs around chaining (.) operations

There were some cases of chaining operators not being evaluated
correctly. One was due to not checking for end tokens with `newLine`
properties.

Fixes #469
Fixes #348

_3. Better cleanup of indented multi-line conditional statements.

Just some cleanup of the logic for the conditional in an if statement.

_4. Empty if conditionals now do not generate indent message

While I think more often than not you should never need to have an empty
if conditional in your code. I do recognize it probably will happen, and
someone who chooses to use one should not be punished for it with an
indentation issue.

Closes #312