### PR TITLE
Small api fixes

### DIFF
--- a/src/lexical_linter.coffee
+++ b/src/lexical_linter.coffee
@@ -58,7 +58,7 @@ module.exports = class LexicalLinter extends BaseLinter
         @tokenApi.lineNumber = @lineNumber
 
         # Multiple rules might run against the same token to build context.
-        # Every every rule should run even if something has already produced an
+        # Every rule should run even if something has already produced an
         # error for the same token.
         errors = []
         for rule in @rules when token[0] in rule.tokens

--- a/src/lexical_linter.coffee
+++ b/src/lexical_linter.coffee
@@ -67,7 +67,7 @@ module.exports = class LexicalLinter extends BaseLinter
         errors
 
     createError: (ruleName, attrs = {}) ->
-        attrs.lineNumber = @lineNumber + 1
-        attrs.line = @tokenApi.lines[@lineNumber]
+        attrs.lineNumber ?= @lineNumber
+        attrs.lineNumber += 1
+        attrs.line = @tokenApi.lines[attrs.lineNumber - 1]
         super ruleName, attrs
-

--- a/src/line_linter.coffee
+++ b/src/line_linter.coffee
@@ -32,8 +32,7 @@ class LineApi
                 if @context.class.classIndents is 0
                     @context.class.inClass = false
                     @context.class.classIndents = null
-
-            if @context.class.inClass and not line.match( /^\s*$/ )
+            if not line.match(/^\s*$/)
                 @context.class.lastUnemptyLineInClass = @lineNumber
         else
             unless line.match(/\\s*/)

--- a/src/line_linter.coffee
+++ b/src/line_linter.coffee
@@ -96,7 +96,7 @@ module.exports = class LineLinter extends BaseLinter
         errors = []
         for line, lineNumber in @lineApi.lines
             @lineApi.lineNumber = @lineNumber = lineNumber
-
+            @lineApi.line = @lineApi.lines[lineNumber]
             @lineApi.maintainClassContext line
             @collectInlineConfig line
 

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -63,10 +63,6 @@ module.exports = class MissingFatArrows
     isThis: (node) => @isValue(node) and node.base.value is 'this'
     isFatArrowCode: (node) => @isCode(node) and node.bound
     isConstructor: (node) -> node.variable?.base?.value is 'constructor'
-
-
-
-
     needsFatArrow: (node) ->
         @isCode(node) and (
             any(node.params, (param) => param.contains(@isThis)?) or

--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -1,4 +1,3 @@
-
 module.exports = class NewlinesAfterClasses
 
     rule:

--- a/src/rules/no_backticks.coffee
+++ b/src/rules/no_backticks.coffee
@@ -1,4 +1,3 @@
-
 module.exports = class NoBackticks
 
     rule:


### PR DESCRIPTION
Fixes some typos, extra spaces and...

1. lexical_linter rules can now return custom line numbers.
2. line_linter now returns a proper `line` property (was always null before)