### PR TITLE
newlines_after_classes: rewritten to make it work

### DIFF
--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -7,24 +7,53 @@ module.exports = class NewlinesAfterClasses
         message : 'Wrong count of newlines between a class and other code'
         description: """
         <p>Checks the number of newlines between classes and other code.</p>
-        
+
         Options:
         - <pre><code>value</code></pre> - The number of required newlines
         after class definitions. Defaults to 3.
         """
 
-    lintLine: (line, lineApi) ->
-        ending = lineApi.config[@rule.name].value
+    tokens: ['CLASS', '}', '{']
 
-        return null if not ending or lineApi.isLastLine()
+    classBracesCount: 0
+    classCount: 0
 
-        { lineNumber, context } = lineApi
-        if not context.class.inClass and
-                context.class.lastUnemptyLineInClass? and
-                (lineNumber - context.class.lastUnemptyLineInClass) isnt
-                ending
-            got = lineNumber - context.class.lastUnemptyLineInClass
-            return  { context: "Expected #{ending} got #{got}" }
+    lintToken: (token, tokenApi) ->
+        [type, numIndents, { first_line: lineNumber }] = token
+        { lines, lineNumber } = tokenApi
 
-        null
+        ending = tokenApi.config[@rule.name].value
+        if type is 'CLASS'
+            @classCount++
 
+        if @classCount > 0 and token.generated?
+            if type is '{' and token.origin?[0] is ':'
+                @classBracesCount++
+
+            if type is '}' and token.origin?[0] is 'OUTDENT'
+                @classBracesCount--
+                @classCount--
+                if @classCount is 0 and @classBracesCount is 0
+                    befores = 1
+                    afters = 1
+                    comment = 0
+                    while (/^\s*(#|$)/.test(lines[lineNumber + afters]))
+                        if /^\s*#/.test(lines[lineNumber + afters])
+                            comment += 1
+                        afters += 1
+
+                    while (/^\s*(#|$)/.test(lines[lineNumber - befores]))
+                        befores += 1
+
+                    # add up blank lines, subtract comments, subtract 2 because
+                    # before/after counters started at 1.
+                    got = afters + befores - comment - 2
+                    trueLine = lineNumber + afters - befores - comment
+
+                    # if `got` and `ending` don't match throw an error _unless_
+                    # we are at the end of the file.
+                    if got isnt ending and trueLine + ending <= lines.length
+                        return {
+                            context: "Expected #{ending} got #{got}"
+                            lineNumber: trueLine
+                        }

--- a/test/test_newlines_after_classes.coffee
+++ b/test/test_newlines_after_classes.coffee
@@ -3,23 +3,22 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
+rule = 'newlines_after_classes'
+vows.describe(rule).addBatch({
 
-vows.describe('newlines_after_classes').addBatch({
+    'File ends with end of class':
+        topic:
+            '''
+            class Foo
 
-    'Classfile ends with end of class' :
+                constructor: () ->
+                    bla()
 
-        topic : () ->
-            """
-                class Foo
+                a: 'b'
+                c: 'd'
+            '''
 
-                    constructor: () ->
-                        bla()
-
-                    a: "b"
-                    c: "d"
-            """
-
-        "won't match" : (source) ->
+        "won't match": (source) ->
             config =
                 newlines_after_classes:
                     level: 'error'
@@ -30,14 +29,12 @@ vows.describe('newlines_after_classes').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
-
-    'Class with arbitrary Code following' :
-
-        topic : () ->
-            """
+    'Class with arbitrary Code following':
+        topic:
+            '''
             class Foo
 
-                constructor: ( ) ->
+                constructor: () ->
                     bla()
 
                 a: "b"
@@ -47,11 +44,11 @@ vows.describe('newlines_after_classes').addBatch({
 
             class Bar extends Foo
 
-                constructor: ( ) ->
+                constructor: () ->
                     bla()
-            """
+            '''
 
-        "defaults to ignore newlines_after_classes" : (source) ->
+        'defaults to ignore newlines_after_classes': (source) ->
             config =
                 indentation:
                     level: 'ignore'
@@ -59,7 +56,7 @@ vows.describe('newlines_after_classes').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
-        "has too few newlines after class" : (source) ->
+        'has too few newlines after class': (source) ->
             config =
                 newlines_after_classes:
                     level: 'error'
@@ -74,9 +71,9 @@ vows.describe('newlines_after_classes').addBatch({
             assert.equal(error.message, msg)
             assert.equal(error.rule, 'newlines_after_classes')
             assert.equal(error.lineNumber, 10)
-            assert.equal(error.context, "Expected 4 got 3")
+            assert.equal(error.context, 'Expected 4 got 3')
 
-        "has too many newlines after class" : (source) ->
+        'has too many newlines after class': (source) ->
             config =
                 newlines_after_classes:
                     level: 'error'
@@ -91,9 +88,9 @@ vows.describe('newlines_after_classes').addBatch({
             assert.equal(error.message, msg)
             assert.equal(error.rule, 'newlines_after_classes')
             assert.equal(error.lineNumber, 10)
-            assert.equal(error.context, "Expected 2 got 3")
+            assert.equal(error.context, 'Expected 2 got 3')
 
-        "works OK" : (source) ->
+        'has no errors': (source) ->
             config =
                 newlines_after_classes:
                     level: 'error'
@@ -103,5 +100,208 @@ vows.describe('newlines_after_classes').addBatch({
                     value: 4
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
+
+    'Fix #230, error when class ends with function':
+        topic:
+            '''
+            class Foo
+              bar: ->
+                "foo"
+
+            return Foo
+            '''
+
+        'passes properly with value of 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 1)
+
+    'Fix #245, error of class inside function call':
+        topic:
+            '''
+            test(->
+
+              class SomeClass
+
+                someFunction: ->
+                  someCode()
+
+
+              someCode()
+              return
+            )
+            '''
+
+        'fails with value of 1': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 1
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 7)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 1 got 2')
+
+        'passes properly with value of 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'fails with value of 3': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 3
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 7)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 3 got 2')
+
+    'Fix #245, other case':
+        topic:
+            '''
+            a 'test case', ->
+              b 'sub-test case', ->
+                class C extends D
+                  @hello: ->
+                    @exit()
+
+                f = result()
+            '''
+
+        'fails with value of 0': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 0
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 6)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 0 got 1')
+
+        'passes with value of 1': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 1
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'fails with value of 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 6)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 2 got 1')
+
+    'Fix #347, error when class ends with non-function property':
+        topic:
+            '''
+            class WhitespaceTest
+              key1: 'a'
+              key2: 'b'
+
+            '''
+
+        'passes properly with value of 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            error = errors[0]
+            assert.equal(errors.length, 0)
+
+    'Fix #375, comments should not count as an empty line':
+        topic:
+            '''
+            class A
+              B: ->
+
+            # comment
+            FooBar()
+            '''
+
+        'defaults to ignore newlines_after_classes': (source) ->
+            errors = coffeelint.lint(source)
+            assert.equal(errors.length, 0)
+
+        'throws error when newlines_after_classes is set to 0': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 0
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 3)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 0 got 1')
+
+        'ignores comment when newlines_after_classes is set to 1': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 1
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'throws error when newlines_after_classes is set to 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 3)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 2 got 1')
+
+        'throws error when newlines_after_classes is set to 3': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 3
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 3)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, rule)
+            assert.equal(errors[0].context, 'Expected 3 got 1')
 
 }).export(module)


### PR DESCRIPTION
newline_after_classes has been rewritten to use the lexical linter
rather than the line linter. The previously written code did not catch a
lot of the extra cases caused by CoffeeScript's tokenizer/lexer.

This should now be much more accurate, this will now ignore classes
scoped within other classes (will just be generally ignored)

Fixes #230
Fixes #245
Fixes #347
Fixes #375