### PR TITLE
no_this: make compatible with no_stand_alone_at

### DIFF
--- a/src/rules/no_stand_alone_at.coffee
+++ b/src/rules/no_stand_alone_at.coffee
@@ -1,21 +1,21 @@
-
 module.exports = class NoStandAloneAt
 
     rule:
         name: 'no_stand_alone_at'
-        level : 'ignore'
-        message : '@ must not be used stand alone'
-        description: """
+        level: 'ignore'
+        message: '@ must not be used stand alone'
+        description:
+            '''
             This rule checks that no stand alone @ are in use, they are
             discouraged. Further information in CoffeScript issue <a
             href="https://github.com/jashkenas/coffee-script/issues/1601">
             #1601</a>
-            """
+            '''
 
 
-    tokens: [ '@' ]
+    tokens: ['@']
 
-    lintToken : (token, tokenApi) ->
+    lintToken: (token, tokenApi) ->
         nextToken = tokenApi.peek()
         spaced = token.spaced
         isIdentifier = nextToken[0] is 'IDENTIFIER'
@@ -31,7 +31,7 @@ module.exports = class NoStandAloneAt
             isValidProtoProperty = protoProperty[0] is 'IDENTIFIER'
 
         if spaced or (not isIdentifier and not isIndexStart and
-        not isDot and not isValidProtoProperty)
+                not isDot and not isValidProtoProperty)
             return true
 
 

--- a/src/rules/no_this.coffee
+++ b/src/rules/no_this.coffee
@@ -1,14 +1,19 @@
-
 module.exports = class NoThis
     rule:
         name: 'no_this'
-        description: '''
-        This rule prohibits 'this'.
-        Use '@' instead.
-        '''
         level: 'ignore'
         message: "Don't use 'this', use '@' instead"
+        description:
+            '''
+            This rule prohibits 'this'.
+            Use '@' instead.
+            '''
 
     tokens: ['THIS']
+
     lintToken: (token, tokenApi) ->
-        true
+        { config: { no_stand_alone_at: { level } } } = tokenApi
+        nextToken = tokenApi.peek(1)?[0]
+
+        true unless level isnt 'ignore' and nextToken isnt '.'
+

--- a/test/test_no_this.coffee
+++ b/test/test_no_this.coffee
@@ -5,25 +5,29 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 configError = {no_this: {level: 'error'}}
 
-vows.describe('no_this').addBatch({
+rule = 'no_this'
+
+vows.describe(rule).addBatch({
 
     'this':
         'should warn when \'this\' is used': ->
             result = coffeelint.lint('this.foo()', configError)[0]
             assert.equal(result.lineNumber, 1)
-            assert.equal(result.rule, 'no_this')
+            assert.equal(result.rule, rule)
 
     '@':
         'should not warn when \'@\' is used': ->
             assert.isEmpty(coffeelint.lint('@foo()', configError))
 
-    'Comments': ->
-        topic: """
-        # this.foo()
-        ###
-        this.foo()
-        ###
-        """
+    'Comments':
+        topic:
+            '''
+            # this.foo()
+            ###
+            this.foo()
+            ###
+            '''
+
         'should not warn when \'this\' is used in a comment': (source) ->
             assert.isEmpty(coffeelint.lint(source, configError))
 
@@ -41,5 +45,62 @@ vows.describe('no_this').addBatch({
                 """
             '''
             assert.isEmpty(coffeelint.lint(source, configError))
+
+    'Compatibility with no_stand_alone_at':
+        topic:
+            '''
+            class X
+              constructor: ->
+                this
+
+            class Y extends X
+              constructor: ->
+                this.hello
+
+            '''
+
+        'returns an error if no_stand_alone_at is on ignore': (source) ->
+            config =
+                no_stand_alone_at:
+                    level: 'ignore'
+                no_this:
+                    level: 'error'
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 2)
+            error = errors[0]
+            assert.equal(error.lineNumber, 3)
+            assert.equal(error.rule, rule)
+
+            error = errors[1]
+            assert.equal(error.lineNumber, 7)
+            assert.equal(error.rule, rule)
+
+        'returns no errors if no_stand_alone_at is on warn/error': (source) ->
+            config =
+                no_stand_alone_at:
+                    level: 'warn'
+                no_this:
+                    level: 'error'
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+
+            error = errors[0]
+            assert.equal(error.lineNumber, 7)
+            assert.equal(error.rule, rule)
+
+            config =
+                no_stand_alone_at:
+                    level: 'error'
+                no_this:
+                    level: 'error'
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+
+            error = errors[0]
+            assert.equal(error.lineNumber, 7)
+            assert.equal(error.rule, rule)
 
 }).export(module)


### PR DESCRIPTION
If `no_stand_alone_at` is set to warn or error, then it will suppress
any errors that come from this rule when the code uses a singular
`this`. It will continue checking this rule for non stand-alone this.

Fixes #464