### PR TITLE
missing_fat_arrows: remove requirement for prototypes

### DIFF
--- a/src/ast_linter.coffee
+++ b/src/ast_linter.coffee
@@ -83,5 +83,3 @@ module.exports = class ASTLinter extends BaseLinter
             lineNumber: lineNumber
         }
         return  @createError 'coffeescript_error', attrs
-
-

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -17,7 +17,8 @@ module.exports = class MissingFatArrows
         level: 'ignore'
         is_strict: false
         message: 'Used `this` in a function without a fat arrow'
-        description: """
+        description:
+            '''
             Warns when you use `this` inside a function that wasn't defined
             with a fat arrow. This rule does not apply to methods defined in a
             class, since they have `this` bound to the class instance (or the
@@ -28,20 +29,21 @@ module.exports = class MissingFatArrows
             `this` will be bound with the correct `this` value due to language
             features like `Function.prototype.call` and
             `Function.prototype.bind`, so this rule may produce false positives.
-            """
+            '''
 
     lintAST: (node, @astApi) ->
         @lintNode node
         undefined
 
     lintNode: (node, methods = []) ->
-        is_strict = @astApi.config[@rule.name]?.is_strict
+        isStrict = @astApi.config[@rule.name]?.is_strict
+
         if @isConstructor node
             return
 
         if (not @isFatArrowCode node) and
                 # Ignore any nodes we know to be methods
-                (if is_strict then true else node not in methods) and
+                (if isStrict then true else node not in methods) and
                 (@needsFatArrow node)
             error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -38,6 +38,9 @@ module.exports = class MissingFatArrows
     lintNode: (node, methods = []) ->
         isStrict = @astApi.config[@rule.name]?.is_strict
 
+        if @isPrototype(node)
+            return
+
         if @isConstructor node
             return
 
@@ -62,6 +65,11 @@ module.exports = class MissingFatArrows
     isClass: (node) => @astApi.getNodeName(node) is 'Class'
     isValue: (node) => @astApi.getNodeName(node) is 'Value'
     isObject: (node) => @astApi.getNodeName(node) is 'Obj'
+    isPrototype: (node) =>
+        props = node?.variable?.properties or []
+        for ident in props when ident.name?.value is 'prototype'
+            return true
+        false
     isThis: (node) => @isValue(node) and node.base.value is 'this'
     isFatArrowCode: (node) => @isCode(node) and node.bound
     isConstructor: (node) -> node.variable?.base?.value is 'constructor'

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 vows = require 'vows'
 assert = require 'assert'
-{inspect} = require 'util'
+{ inspect } = require 'util'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 RULE = 'missing_fat_arrows'
@@ -52,133 +52,133 @@ vows.describe(RULE).addBatch({
         'with fat arrow'      : shouldPass '-> -> -> -> => this'
         'with wrong fat arrow': shouldError '-> -> => -> -> this'
 
-    'functions with multiple statements' : shouldError """
+    'functions with multiple statements': shouldError '''
         f = ->
             this.x = 2
             z ((a) -> a; this.x)
-        """, 2
+        ''', 2
 
     'functions with parameters'                        : shouldPass '(a) ->'
     'functions with parameter assignment'              : shouldError '(@a) ->'
     'functions with destructuring parameter assignment': shouldError '({@a}) ->'
 
     'class instance method':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 @m: -> 1
-            """
-        'with this': shouldPass """
+            '''
+        'with this': shouldPass '''
             class A
                 @m: -> this
-            """
+            '''
 
     'class instance method in strict mode':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 @m: -> 1
-            """, true
-        'with this': shouldError """
+            ''', true
+        'with this': shouldError '''
             class A
                 @m: -> this
-            """, null, true
+            ''', null, true
 
     # https://github.com/clutchski/coffeelint/issues/412
-    'do methods should not error': shouldPass """
+    'do methods should not error': shouldPass '''
         do -> 1
-        """
+        '''
 
     'class method':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 m: -> 1
-            """
-        'with this': shouldPass """
+            '''
+        'with this': shouldPass '''
             class A
                 m: -> this
-            """
+            '''
 
     'class method in strict mode':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 m: -> 1
-            """, true
-        'with this': shouldError """
+            ''', true
+        'with this': shouldError '''
             class A
                 m: -> this
-            """, null, true
+            ''', null, true
 
     'class constructor in strict mode':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 constructor: -> 1
-            """, true
-        'with this': shouldPass """
+            ''', true
+        'with this': shouldPass '''
             class A
                 constructor: -> this
                 dd: 'constructor'
                 xx: -> 'constructor'
-            """, true
+            ''', true
 
     'function in class body':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 f = -> 1
                 x: 2
-            """
-        'with this': shouldError """
+            '''
+        'with this': shouldError '''
             class A
                 f = -> this
                 x: 2
-            """
+            '''
 
     'function inside class instance method':
-        'without this': shouldPass """
+        'without this': shouldPass '''
             class A
                 m: -> -> 1
-            """
-        'with this': shouldError """
+            '''
+        'with this': shouldError '''
             class A
                 m: -> -> @a
-            """
+            '''
 
     'mixture of class methods and function in class body':
-        'with this': shouldPass """
+        'with this': shouldPass '''
             class A
                 f = => this
                 m: -> this
                 @n: -> this
                 o: -> this
                 @p: -> this
-            """
+            '''
 
     'mixture of class methods and function in class body in strict mode':
-        'with this': shouldPass """
+        'with this': shouldPass '''
             class A
                 f = => this
                 m: => this
                 @n: => this
                 o: => this
                 @p: => this
-            """, true
+            ''', true
 
     'https://github.com/clutchski/coffeelint/issues/215':
-        'method with block comment': shouldPass """
+        'method with block comment': shouldPass '''
             class SimpleClass
 
                 ###
                 A block comment
                 ###
                 doNothing: () ->
-        """
-    'function ouside class instance method':
-        'without this': shouldPass """
+            '''
+    'function outside class instance method':
+        'without this': shouldPass '''
             ->
                 class A
                     m: ->
-                """
-        'with this': shouldPass """
+            '''
+        'with this': shouldPass '''
             ->
                 class A
                     @m: ->
-                """
+            '''
 }).export(module)

--- a/test/test_missing_fat_arrows.coffee
+++ b/test/test_missing_fat_arrows.coffee
@@ -181,4 +181,10 @@ vows.describe(RULE).addBatch({
                 class A
                     @m: ->
             '''
+    'do not require fat arrows in prototype (::) methods':
+        'method declared by :: (Fixes #296)': shouldPass '''
+            X::getName = ->
+                @name
+            '''
+
 }).export(module)


### PR DESCRIPTION
Prototypes are no longer requirement to use a fat arrow.

```coffeescript
SuperHero::getPower = ->
  @power
```

This will now not return an error.

Fixes #296