### PR TITLE
arrow_spacing: empty functions redux

### DIFF
--- a/src/rules/arrow_spacing.coffee
+++ b/src/rules/arrow_spacing.coffee
@@ -47,8 +47,8 @@ module.exports = class ArrowSpacing
 
         return unless pp
 
+        # Ignore empty functions
         if not token.spaced and
-                (pp[1] is "(" and not pp.generated?) and
                 tokenApi.peek(1)[0] is 'INDENT' and
                 tokenApi.peek(2)[0] is 'OUTDENT'
             null

--- a/src/rules/arrow_spacing.coffee
+++ b/src/rules/arrow_spacing.coffee
@@ -52,7 +52,7 @@ module.exports = class ArrowSpacing
                 tokenApi.peek(1)[0] is 'INDENT' and
                 tokenApi.peek(2)[0] is 'OUTDENT'
             null
-        else unless (token.spaced? or token.newLine? or @atEof(tokenApi)) and
+        else unless (token.spaced? or token.newLine?) and
                # Throw error unless the previous token...
                ((pp.spaced? or pp[0] is 'TERMINATOR') or #1
                 pp.generated? or #2
@@ -61,11 +61,3 @@ module.exports = class ArrowSpacing
             true
         else
             null
-
-    # Are there any more meaningful tokens following the current one?
-    atEof: (tokenApi) ->
-        { tokens, i } = tokenApi
-        for token in tokens.slice(i + 1)
-            unless token.generated or token[0] in ['OUTDENT', 'TERMINATOR']
-                return false
-        true

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -231,20 +231,6 @@ vows.describe('arrows').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
-    'Handle an arrow at end of file' :
-        topic : ->
-            '{f: ->}'
-
-        'when spacing is required around arrow operator' : (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
-            errors = coffeelint.lint(source, config)
-            assert.equal(errors.length, 1)
-
-        'when spacing is not required around arrow operator' : (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
-            errors = coffeelint.lint(source, config)
-            assert.isEmpty(errors, 0)
-
     'Handle an arrow at beginning of file' :
         topic : ->
             '-> foo()'

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -163,6 +163,24 @@ vows.describe('arrows').addBatch({
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
+    'Handle an empty arrow at end of expression' :
+        topic : ->
+            '''
+            (x = ->)
+            {x: ->}
+            (x: ->)
+            '''
+
+        'when spacing is required around arrow operator' : (source) ->
+            config = { "arrow_spacing": { "level": "error" } }
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'when spacing is not required around arrow operator' : (source) ->
+            config = { "arrow_spacing": { "level": "ignore" } }
+            errors = coffeelint.lint(source, config)
+            assert.isEmpty(errors, 0)
+
     'Handle a nested arrow at end of file' :
         topic : ->
             'class A\n  f: ->'


### PR DESCRIPTION
This fixes #304 (and generalises #173, and obsoletes #148).

I basically removed the guard in #173 so now any empty function is ignored by the rule. #148 was ignoring empty functions only at the end of files, which is no longer necessary because those are a subset of the new behaviour.

It passes all the tests, but there's a possibility that the existing empty function behaviour was restricted for a reason that I don't understand. Feedback welcome!