### PR TITLE
indent: fix chaining problems caused by regression

### DIFF
--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -48,7 +48,6 @@ module.exports = class Indentation
             # the linting pass if the '.' token is not at the beginning of
             # the line
             currentLine = lines[lineNumber]
-
             if currentLine.match(/\S/)?[0] is '.'
                 return @handleChain(tokenApi, expected)
             return undefined
@@ -118,8 +117,7 @@ module.exports = class Indentation
         # Traverse up the token list until we see a CALL_START token.
         # Don't scan above this line
         findCallStart = tokenApi.peek(-callStart)
-        while (findCallStart and (findCallStart[0] isnt 'TERMINATOR' or
-                not findCallStart.newLine?))
+        while (findCallStart and findCallStart[0] isnt 'TERMINATOR')
             { first_line: lastCheck } = findCallStart[2]
 
             callStart += 1

--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -56,7 +56,7 @@ module.exports = class Indentation
             @lintArray(token)
             return undefined
 
-        return null if token.generated?
+        return null if token.generated? or token.explicit?
 
         # HACK: CoffeeScript's lexer insert indentation in string
         # interpolations that start with spaces e.g. "#{ 123 }"

--- a/test/test_indentation.coffee
+++ b/test/test_indentation.coffee
@@ -3,7 +3,6 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-
 vows.describe('indent').addBatch({
 
     'Indentation' :
@@ -521,20 +520,19 @@ vows.describe('indent').addBatch({
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
-    # Fix #348
-    'Handle off-indentation bug from arguments that should be ignored':
+    # Fix #504, a regression caused by bffa2532efd8bcca5d9c1b3a9d3b5914e882dd5f
+    # Reverted test for now that fixed #348, since the alignment was a bit
+    # unorthodox
+    'Handle leakage of (.) chained calls':
         topic:
             '''
-            angular.module('app', ['abc']).run([
-              '$a'
-              '$b'
-              ($xyz
-               $tuv
-               $qrs) ->
-                $http
-                  .get '/'
-                  .respond -> []
-            ])
+            func = ->
+              """
+                multiline string
+                 .looksLikeAFunc 'but its just a string, man!'
+              """
+            func()
+              .length
             '''
 
         'is permitted': (source) ->

--- a/test/test_indentation.coffee
+++ b/test/test_indentation.coffee
@@ -539,4 +539,33 @@ vows.describe('indent').addBatch({
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
+    # Fix #511 by ignoring explicitly generated indentation tabs.
+    'Handle empty try/catch/finally':
+        topic:
+            '''
+            try
+              a
+            catch
+              # catch but do nothing
+
+            try
+            catch
+            finally
+
+            try a catch b finally
+
+            try
+              a
+            catch
+              # nothing
+            finally
+              c
+              d
+            '''
+
+        'is permitted': (source) ->
+            errors = coffeelint.lint(source)
+            assert.isEmpty(errors)
+
+
 }).export(module)


### PR DESCRIPTION
This fixes problems with chaining identifying separate code blocks as
the same chain.

This also reverts where we ignored the slightly off alignment that we
allowed from #348.

See issue #504.