### PR TITLE
indent: remove isInterpIndent check

### DIFF
--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -59,13 +59,6 @@ module.exports = class Indentation
 
         return null if token.generated?
 
-        # HACK: CoffeeScript's lexer insert indentation in string
-        # interpolations that start with spaces e.g. "#{ 123 }"
-        # so ignore such cases. Are there other times an indentation
-        # could possibly follow a '+'?
-        previous = tokenApi.peek(-2)
-        isInterpIndent = previous and previous[0] is '+'
-
         # Ignore the indentation inside of an array, so that
         # we can allow things like:
         #   x = ["foo",
@@ -81,7 +74,7 @@ module.exports = class Indentation
         isMultiline = previousSymbol in ['=', ',']
 
         # Summarize the indentation conditions we'd like to ignore
-        ignoreIndent = isInterpIndent or isArrayIndent or isMultiline
+        ignoreIndent = isArrayIndent or isMultiline
 
         # Correct CoffeeScript's incorrect INDENT token value when functions
         # get chained. See https://github.com/jashkenas/coffeescript/issues/3137


### PR DESCRIPTION
This removes the isInterpIndent check in the indent rule. It seems that
since the fixes made in CoffeeScript 1.9.x, this check is no longer
needed.