### PR TITLE
missing_fat_arrows: remove unnecessary fat arrow

### DIFF
--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -65,7 +65,7 @@ module.exports = class MissingFatArrows
     isClass: (node) => @astApi.getNodeName(node) is 'Class'
     isValue: (node) => @astApi.getNodeName(node) is 'Value'
     isObject: (node) => @astApi.getNodeName(node) is 'Obj'
-    isPrototype: (node) =>
+    isPrototype: (node) ->
         props = node?.variable?.properties or []
         for ident in props when ident.name?.value is 'prototype'
             return true


### PR DESCRIPTION
Removed fat arrow that was introduced in
30e28a6f362abadd3aa450bb7e0402060d909d29