### PR TITLE
CSVReporter: Properly double quote field

### DIFF
--- a/src/reporters/csv.coffee
+++ b/src/reporters/csv.coffee
@@ -1,25 +1,25 @@
 module.exports = class CSVReporter
 
-    constructor : (@errorReport, options = {}) ->
+    constructor: (@errorReport, options = {}) ->
 
-    print : (message) ->
+    print: (message) ->
         # coffeelint: disable=no_debugger
         console.log message
         # coffeelint: enable=no_debugger
 
-    publish : () ->
-        header = ["path","lineNumber", "lineNumberEnd", "level", "message"]
+    publish: () ->
+        header = ["path", "lineNumber", "lineNumberEnd", "level", "message"]
         @print header.join(",")
         for path, errors of @errorReport.paths
             for e in errors
                 # Having the context is useful for the cyclomatic_complexity
                 # rule and critical for the undefined_variables rule.
-                e.message += " #{e.context}." if e.context
+                e.message += " #{e.context}" if e.context
                 f = [
                     path
                     e.lineNumber
                     e.lineNumberEnd ? e.lineNumberEnd
                     e.level
-                    e.message
+                    '"' + e.message.replace(/\"/g, "") + '"'
                 ]
                 @print f.join(",")

--- a/src/reporters/raw.coffee
+++ b/src/reporters/raw.coffee
@@ -1,11 +1,11 @@
 module.exports = class RawReporter
 
-    constructor : (@errorReport, options = {}) ->
+    constructor: (@errorReport, options = {}) ->
 
-    print : (message) ->
+    print: (message) ->
         # coffeelint: disable=no_debugger
         console.log message
         # coffeelint: enable=no_debugger
 
-    publish : () ->
+    publish: () ->
         @print JSON.stringify(@errorReport.paths, undefined, 2)


### PR DESCRIPTION
Follows this http://tools.ietf.org/html/rfc4180 in regards to using
double quotes around fields that can have commas or spaces, as well as
using two quotes ("") to escape inside a field's value

Closes #298
