### PR TITLE
test_commandline: use deepEqual for minimal JSON check

### DIFF
--- a/test/test_commandline.coffee
+++ b/test/test_commandline.coffee
@@ -244,10 +244,10 @@ vows.describe('commandline').addBatch({
 
         'is minimal' : (error, config) ->
             expected = fs.readFileSync(
-                path.join(__dirname, '..', 'coffeelint.json')
-            ).toString()
+                path.join(__dirname, '..', 'coffeelint.json'), 'utf-8'
+            )
 
-            assert.equal(config, expected)
+            assert.deepEqual(JSON.parse(config), JSON.parse(expected))
 
     'does not fail on warnings' :
 


### PR DESCRIPTION
This changes the test for "minimal" config to do a deepEqual comparison
check between the config and the minimal output rather than doing a
string comparison which could be different due to how javascript orders
keys in the object.