### PR TITLE
no_unnecessary_double_quotes: add for coffeelint dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ module.exports = class NoComment
         name: 'no_comment'
         level: 'ignore'
         message: 'No comment'
-        description: """
+        description: '''
             Disallows any comment in the code
-            """
+            '''
 
     tokens: ['#', '###']
 
@@ -69,7 +69,7 @@ module.exports = class NoComment
 
 The description property is a string that can embed HTML code:
 ```html
-description: """
+description: '''
 	Disallows any comment in the code. This code would not pass:
 	<pre>
 	<code>### Some code with comments
@@ -78,7 +78,7 @@ description: """
 		bar()
 	</code>
 	</pre>
-	"""
+	'''
 ```
 [Coffeelint's website](http://www.coffeelint.org/) generates each
 rule's documentation based on this `description` property.

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -25,5 +25,8 @@
     "no_debugger": {
         "level": "error",
         "console": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "error"
     }
 }

--- a/src/base_linter.coffee
+++ b/src/base_linter.coffee
@@ -34,7 +34,7 @@ module.exports = class BaseLinter
             null
 
     acceptRule: (rule) ->
-        throw new Error "acceptRule needs to be overridden in the subclass"
+        throw new Error 'acceptRule needs to be overridden in the subclass'
 
     # Only rules that have a level of error or warn will even get constructed.
     setupRules: (rules) ->

--- a/src/cache.coffee
+++ b/src/cache.coffee
@@ -1,8 +1,8 @@
-fs = require "fs"
-path = require "path"
-crypto = require "crypto"
+fs = require 'fs'
+path = require 'path'
+crypto = require 'crypto'
 
-ltVer = require("./../package.json").version
+ltVer = require('./../package.json').version
 csVer = (window?.CoffeeScript or require 'coffee-script').VERSION
 
 

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -128,8 +128,8 @@ coffeelint.invertLiterate = (source) ->
     source = CoffeeScript.helpers.invertLiterate source
     # Strip the first 4 spaces from every line. After this the markdown is
     # commented and all of the other code should be at their natural location.
-    newSource = ""
-    for line in source.split "\n"
+    newSource = ''
+    for line in source.split '\n'
         if line.match(/^#/)
             # strip trailing space
             line = line.replace /\s*$/, ''
@@ -145,18 +145,18 @@ _rules = {}
 coffeelint.registerRule = (RuleConstructor, ruleName = undefined) ->
     p = new RuleConstructor
 
-    name = p?.rule?.name or "(unknown)"
+    name = p?.rule?.name or '(unknown)'
     e = (msg) -> throw new Error "Invalid rule: #{name} #{msg}"
     unless p.rule?
-        e "Rules must provide rule attribute with a default configuration."
+        e 'Rules must provide rule attribute with a default configuration.'
 
-    e "Rule defaults require a name" unless p.rule.name?
+    e 'Rule defaults require a name' unless p.rule.name?
 
     if ruleName? and ruleName isnt p.rule.name
         e "Mismatched rule name: #{ruleName}"
 
-    e "Rule defaults require a message" unless p.rule.message?
-    e "Rule defaults require a description" unless p.rule.description?
+    e 'Rule defaults require a message' unless p.rule.message?
+    e 'Rule defaults require a description' unless p.rule.description?
     unless p.rule.level in [ 'ignore', 'warn', 'error' ]
         e "Default level must be 'ignore', 'warn', or 'error'"
 
@@ -164,7 +164,7 @@ coffeelint.registerRule = (RuleConstructor, ruleName = undefined) ->
         e "'tokens' is required for 'lintToken'" unless p.tokens
     else if typeof p.lintLine isnt 'function' and
             typeof p.lintAST isnt 'function'
-        e "Rules must implement lintToken, lintLine, or lintAST"
+        e 'Rules must implement lintToken, lintLine, or lintAST'
 
     # Capture the default options for the new rule.
     RULES[p.rule.name] = p.rule
@@ -254,7 +254,7 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
 
     source = @invertLiterate source if literate
     if userConfig?.coffeelint?.transforms?
-        sourceLength = source.split("\n").length
+        sourceLength = source.split('\n').length
         for m in userConfig?.coffeelint?.transforms
             try
                 ruleLoader = nodeRequire './ruleLoader'
@@ -265,7 +265,7 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
         # changes one line into two early in the file and later condenses two
         # into one you'll end up with the same length and not get the warning
         # even though everything in between will be off by one.
-        if sourceLength isnt source.split("\n").length and
+        if sourceLength isnt source.split('\n').length and
                 config.transform_messes_up_line_numbers.level isnt 'ignore'
 
             errors.push(extend(

--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -7,18 +7,18 @@ CoffeeLint is freely distributable under the MIT license.
 
 
 resolve = require('resolve').sync
-path = require("path")
-fs   = require("fs")
-os   = require("os")
-glob = require("glob")
-optimist = require("optimist")
+path = require('path')
+fs   = require('fs')
+os   = require('os')
+glob = require('glob')
+optimist = require('optimist')
 ignore = require('ignore')
 stripComments = require('strip-json-comments')
 thisdir = path.dirname(fs.realpathSync(__filename))
-coffeelint = require(path.join(thisdir, "coffeelint"))
-configfinder = require(path.join(thisdir, "configfinder"))
+coffeelint = require(path.join(thisdir, 'coffeelint'))
+configfinder = require(path.join(thisdir, 'configfinder'))
 ruleLoader = require(path.join(thisdir, 'ruleLoader'))
-Cache = require(path.join(thisdir, "cache"))
+Cache = require(path.join(thisdir, 'cache'))
 CoffeeScript = require 'coffee-script'
 CoffeeScript.register()
 
@@ -76,7 +76,7 @@ lintSource = (source, config, literate = false) ->
     errorReport = new coffeelint.getErrorReport()
     config or= getFallbackConfig()
 
-    errorReport.lint("stdin", source, config, literate)
+    errorReport.lint('stdin', source, config, literate)
     return errorReport
 
 # Load a config file given a path/filename
@@ -112,11 +112,11 @@ getFallbackConfig = (filename = null) ->
 deprecatedReporter = (errorReport, reporter) ->
     errorReport.paths['coffeelint_fake_file.coffee'] ?= []
     errorReport.paths['coffeelint_fake_file.coffee'].push {
-        "level": "warn"
-        "rule": "commandline"
-        "message": "parameter --#{reporter} is deprecated.
+        'level': 'warn'
+        'rule': 'commandline'
+        'message': "parameter --#{reporter} is deprecated.
             Use --reporter #{reporter} instead"
-        "lineNumber": 0
+        'lineNumber': 0
     }
     return reporter
 
@@ -149,11 +149,11 @@ reportAndExit = (errorReport, options) ->
             reporterPath = strReporter
         require reporterPath
 
-    options.argv.color ?= if options.argv.nocolor then "never" else "auto"
+    options.argv.color ?= if options.argv.nocolor then 'never' else 'auto'
 
     colorize = switch options.argv.color
-        when "always" then true
-        when "never" then false
+        when 'always' then true
+        when 'never' then false
         else process.stdout.isTTY
 
     reporter = new SelectedReporter errorReport, {
@@ -167,50 +167,50 @@ reportAndExit = (errorReport, options) ->
 
 # Declare command line options.
 options = optimist
-            .usage("Usage: coffeelint [options] source [...]")
-            .alias("f", "file")
-            .alias("h", "help")
-            .alias("v", "version")
-            .alias("s", "stdin")
-            .alias("q", "quiet")
-            .alias("c", "cache")
-            .describe("f", "Specify a custom configuration file.")
-            .describe("rules", "Specify a custom rule or directory of rules.")
-            .describe("makeconfig", "Prints a default config file")
-            .describe("trimconfig", "Compares your config with the default and
-                prints a minimal configuration")
-            .describe("noconfig", "Ignores any config file.")
-            .describe("h", "Print help information.")
-            .describe("v", "Print current version number.")
-            .describe("r", "(not used, but left for backward compatibility)")
+            .usage('Usage: coffeelint [options] source [...]')
+            .alias('f', 'file')
+            .alias('h', 'help')
+            .alias('v', 'version')
+            .alias('s', 'stdin')
+            .alias('q', 'quiet')
+            .alias('c', 'cache')
+            .describe('f', 'Specify a custom configuration file.')
+            .describe('rules', 'Specify a custom rule or directory of rules.')
+            .describe('makeconfig', 'Prints a default config file')
+            .describe('trimconfig', 'Compares your config with the default and
+                prints a minimal configuration')
+            .describe('noconfig', 'Ignores any config file.')
+            .describe('h', 'Print help information.')
+            .describe('v', 'Print current version number.')
+            .describe('r', '(not used, but left for backward compatibility)')
             .describe('reporter', 'built in reporter (default, csv, jslint,
                 checkstyle, raw), or module, or path to reporter file.')
-            .describe("csv", "[deprecated] use --reporter csv")
-            .describe("jslint", "[deprecated] use --reporter jslint")
-            .describe("nocolor", "[deprecated] use --color=never")
-            .describe("checkstyle", "[deprecated] use --reporter checkstyle")
-            .describe("color=<when>",
-              "When to colorize the output. <when> can be one of always, never\
-              , or auto.")
-            .describe("s", "Lint the source from stdin")
-            .describe("q", "Only print errors.")
-            .describe("literate",
-                "Used with --stdin to process as Literate CoffeeScript")
-            .describe("c", "Cache linting results")
-            .describe("ext",
-                "Specify an additional file extension, separated by comma.")
-            .boolean("csv")
-            .boolean("jslint")
-            .boolean("checkstyle")
-            .boolean("nocolor")
-            .boolean("noconfig")
-            .boolean("makeconfig")
-            .boolean("trimconfig")
-            .boolean("literate")
-            .boolean("r")
-            .boolean("s")
-            .boolean("q", "Print errors only.")
-            .boolean("c")
+            .describe('csv', '[deprecated] use --reporter csv')
+            .describe('jslint', '[deprecated] use --reporter jslint')
+            .describe('nocolor', '[deprecated] use --color=never')
+            .describe('checkstyle', '[deprecated] use --reporter checkstyle')
+            .describe('color=<when>',
+              'When to colorize the output. <when> can be one of always, never \
+              , or auto.')
+            .describe('s', 'Lint the source from stdin')
+            .describe('q', 'Only print errors.')
+            .describe('literate',
+                'Used with --stdin to process as Literate CoffeeScript')
+            .describe('c', 'Cache linting results')
+            .describe('ext',
+                'Specify an additional file extension, separated by comma.')
+            .boolean('csv')
+            .boolean('jslint')
+            .boolean('checkstyle')
+            .boolean('nocolor')
+            .boolean('noconfig')
+            .boolean('makeconfig')
+            .boolean('trimconfig')
+            .boolean('literate')
+            .boolean('r')
+            .boolean('s')
+            .boolean('q', 'Print errors only.')
+            .boolean('c')
 
 if options.argv.v
     log coffeelint.VERSION

--- a/src/configfinder.coffee
+++ b/src/configfinder.coffee
@@ -17,7 +17,7 @@ findFile = (name, dir) ->
     dir = dir or process.cwd()
     filename = path.normalize(path.join(dir, name))
     return findFileResults[filename]  if findFileResults[filename]
-    parent = path.resolve(dir, "../")
+    parent = path.resolve(dir, '../')
     if fs.existsSync(filename)
         findFileResults[filename] = filename
     else if dir is parent
@@ -27,7 +27,7 @@ findFile = (name, dir) ->
 
 # Possibly find CoffeeLint configuration within a package.json file.
 loadNpmConfig = (dir) ->
-    fp = findFile("package.json", dir)
+    fp = findFile('package.json', dir)
     loadJSON(fp)?.coffeelintConfig  if fp
 
 # Parse a JSON file gracefully.
@@ -46,11 +46,11 @@ getConfig = (dir) ->
 
     npmConfig = loadNpmConfig(dir)
     return npmConfig  if npmConfig
-    projConfig = findFile("coffeelint.json", dir)
+    projConfig = findFile('coffeelint.json', dir)
     return loadJSON(projConfig)  if projConfig
 
     envs = process.env.USERPROFILE or process.env.HOME or process.env.HOMEPATH
-    home = path.normalize(path.join(envs, "coffeelint.json"))
+    home = path.normalize(path.join(envs, 'coffeelint.json'))
     if fs.existsSync(home)
         return loadJSON(home)
 

--- a/src/htmldoc.coffee
+++ b/src/htmldoc.coffee
@@ -1,18 +1,17 @@
-_ = require "underscore"
-rules = (require "./coffeelint").RULES
+_ = require 'underscore'
+{ RULES: rules } = (require './coffeelint')
 
 render = () ->
-    rulesHTML = ""
-
+    rulesHTML = ''
     for ruleName in Object.keys(rules).sort()
         rule = rules[ruleName]
         rule.name = ruleName
-        rule.description = "[no description provided]" unless rule.description
+        rule.description = '[no description provided]' unless rule.description
         # coffeelint: disable=no_debugger
         console.log ruleTemplate rule
         # coffeelint: enable=no_debugger
 
-ruleTemplate = _.template """
+ruleTemplate = _.template '''
     <tr>
     <td class="rule"><%= name %></td>
     <td class="description">
@@ -20,6 +19,6 @@ ruleTemplate = _.template """
         <p><em>default level: <%= level %></em></p>
     </td>
     </tr>
-    """
+    '''
 
 render()

--- a/src/line_linter.coffee
+++ b/src/line_linter.coffee
@@ -123,7 +123,7 @@ module.exports = class LineLinter extends BaseLinter
             rules = []
             if result[2]?
                 for r in result[2].split(',')
-                    rules.push r.replace(/^\s+|\s+$/g, "")
+                    rules.push r.replace(/^\s+|\s+$/g, '')
             @block_config[cmd][@lineNumber] = rules
         return null
 

--- a/src/reporters/checkstyle.coffee
+++ b/src/reporters/checkstyle.coffee
@@ -13,8 +13,8 @@ module.exports = class CheckstyleReporter
     escape: JsLintReporter::escape
 
     publish: () ->
-        @print "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-        @print "<checkstyle version=\"4.3\">"
+        @print '<?xml version="1.0" encoding="utf-8"?>'
+        @print '<checkstyle version="4.3">'
 
         for path, errors of @errorReport.paths
             if errors.length
@@ -26,13 +26,13 @@ module.exports = class CheckstyleReporter
 
                     # context is optional, this avoids generating the string
                     # "context: undefined"
-                    context = e.context ? ""
-                    @print """
+                    context = e.context ? ''
+                    @print '''
                     <error line="#{e.lineNumber}"
                         severity="#{@escape(level)}"
                         message="#{@escape(e.message+'; context: '+context)}"
                         source="coffeelint"/>
-                    """
-                @print "</file>"
+                    '''
+                @print '</file>'
 
-        @print "</checkstyle>"
+        @print '</checkstyle>'

--- a/src/reporters/csv.coffee
+++ b/src/reporters/csv.coffee
@@ -8,8 +8,8 @@ module.exports = class CSVReporter
         # coffeelint: enable=no_debugger
 
     publish: () ->
-        header = ["path","lineNumber", "lineNumberEnd", "level", "message"]
-        @print header.join(",")
+        header = ['path', 'lineNumber', 'lineNumberEnd', 'level', 'message']
+        @print header.join(',')
         for path, errors of @errorReport.paths
             for e in errors
                 # Having the context is useful for the cyclomatic_complexity
@@ -22,4 +22,4 @@ module.exports = class CSVReporter
                     e.level
                     e.message
                 ]
-                @print f.join(",")
+                @print f.join(',')

--- a/src/reporters/default.coffee
+++ b/src/reporters/default.coffee
@@ -19,27 +19,27 @@ module.exports = class Reporter
             red: [31, 39]
         }
         return styles.reduce (m, s)  ->
-            return "\u001b[" + map[s][0] + "m" + m + "\u001b[" + map[s][1] + "m"
+            return '\u001b[' + map[s][0] + 'm' + m + '\u001b[' + map[s][1] + 'm'
         , message
 
     publish: () ->
         paths = @errorReport.paths
 
-        report  = ""
+        report  = ''
         report += @reportPath(path, errors) for path, errors of paths
         report += @reportSummary(@errorReport.getSummary())
-        report += ""
+        report += ''
 
         @print report if not @quiet or @errorReport.hasError()
         return this
 
     reportSummary: (s) ->
         start = if s.errorCount > 0
-            "#{@err} #{@stylize("Lint!", 'red', 'bold')}"
+            "#{@err} #{@stylize('Lint!', 'red', 'bold')}"
         else if s.warningCount > 0
-            "#{@warn} #{@stylize("Warning!", 'yellow', 'bold')}"
+            "#{@warn} #{@stylize('Warning!', 'yellow', 'bold')}"
         else
-            "#{@ok} #{@stylize("Ok!", 'green', 'bold')}"
+            "#{@ok} #{@stylize('Ok!', 'green', 'bold')}"
         e = s.errorCount
         w = s.warningCount
         p = s.pathCount
@@ -47,7 +47,7 @@ module.exports = class Reporter
         warn = @plural('warning', w)
         file = @plural('file', p)
         msg = "#{start} » #{e} #{err} and #{w} #{warn} in #{p} #{file}"
-        return "\n" + @stylize(msg) + "\n"
+        return '\n' + @stylize(msg) + '\n'
 
     reportPath: (path, errors) ->
         [overall, color] = if hasError = @errorReport.pathHasError(path)
@@ -57,21 +57,21 @@ module.exports = class Reporter
         else
             [@ok, 'green']
 
-        pathReport = ""
+        pathReport = ''
         if not @quiet or hasError
             pathReport += "  #{overall} #{@stylize(path, color, 'bold')}\n"
 
         for e in errors
             continue if @quiet and e.level isnt 'error'
             o = if e.level is 'error' then @err else @warn
-            lineEnd = ""
+            lineEnd = ''
             lineEnd = "-#{e.lineNumberEnd}" if e.lineNumberEnd?
-            output = "#" + e.lineNumber + lineEnd
+            output = '#' + e.lineNumber + lineEnd
 
-            pathReport += "     " +
+            pathReport += '     ' +
                 "#{o} #{@stylize(output, color)}: #{e.message}."
             pathReport += " #{e.context}." if e.context
-            pathReport += "\n"
+            pathReport += '\n'
 
         pathReport
 

--- a/src/reporters/jslint.coffee
+++ b/src/reporters/jslint.coffee
@@ -8,7 +8,7 @@ module.exports = class JSLintReporter
         # coffeelint: enable=no_debugger
 
     publish: () ->
-        @print "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint>"
+        @print '<?xml version="1.0" encoding="utf-8"?><jslint>'
 
         for path, errors of @errorReport.paths
             if errors.length
@@ -21,24 +21,24 @@ module.exports = class JSLintReporter
                             reason="[#{@escape(e.level)}] #{@escape(e.message)}"
                             evidence="#{@escape(e.context)}"/>
                     """
-                @print "</file>"
+                @print '</file>'
 
-        @print "</jslint>"
+        @print '</jslint>'
 
     escape: (msg) ->
         # Force msg to be a String
-        msg = "" + msg
+        msg = '' + msg
         unless msg
             return
         # Perhaps some other HTML Special Chars should be added here
         # But this are the XML Special Chars listed in Wikipedia
         replacements = [
-            [/&/g, "&amp;"]
-            [/"/g, "&quot;"]
-            [/</g, "&lt;"]
-            [/>/g, "&gt;"]
-            [/'/g, "&apos;"]
-            ]
+            [/&/g, '&amp;']
+            [/"/g, '&quot;']
+            [/</g, '&lt;']
+            [/>/g, '&gt;']
+            [/'/g, '&apos;']
+        ]
 
         for r in replacements
             msg = msg.replace r[0], r[1]

--- a/src/rules/arrow_spacing.coffee
+++ b/src/rules/arrow_spacing.coffee
@@ -4,7 +4,7 @@ module.exports = class ArrowSpacing
         name: 'arrow_spacing'
         level: 'ignore'
         message: 'Function arrows (-> and =>) must be spaced properly'
-        description: """
+        description: '''
             <p>This rule checks to see that there is spacing before and after
             the arrow operator that declares a function. This rule is disabled
             by default.</p> <p>Note that if arrow_spacing is enabled, and you
@@ -20,7 +20,7 @@ module.exports = class ArrowSpacing
             x((a,b)-> 3)
             </code>
             </pre>
-             """
+             '''
 
     tokens: [ '->', '=>' ]
 
@@ -55,8 +55,8 @@ module.exports = class ArrowSpacing
                # Throw error unless the previous token...
                ((pp.spaced? or pp[0] is 'TERMINATOR') or #1
                 pp.generated? or #2
-                pp[0] is "INDENT" or #3
-                (pp[1] is "(" and not pp.generated?)) #4
+                pp[0] is 'INDENT' or #3
+                (pp[1] is '(' and not pp.generated?)) #4
             true
         else
             null

--- a/src/rules/camel_case_classes.coffee
+++ b/src/rules/camel_case_classes.coffee
@@ -8,7 +8,7 @@ module.exports = class CamelCaseClasses
         name: 'camel_case_classes'
         level: 'error'
         message: 'Class name should be UpperCamelCased'
-        description: """
+        description: '''
             This rule mandates that all class names are UpperCamelCased.
             Camel casing class names is a generally accepted way of
             distinguishing constructor functions - which require the 'new'
@@ -22,7 +22,7 @@ module.exports = class CamelCaseClasses
             </code>
             </pre>
             This rule is enabled by default.
-            """
+            '''
 
     tokens: [ 'CLASS' ]
 

--- a/src/rules/colon_assignment_spacing.coffee
+++ b/src/rules/colon_assignment_spacing.coffee
@@ -6,7 +6,7 @@ module.exports = class ColonAssignmentSpacing
         spacing:
             left: 0
             right: 0
-        description: """
+        description: '''
             <p>This rule checks to see that there is spacing before and
             after the colon in a colon assignment (i.e., classes, objects).
             The spacing amount is specified by
@@ -28,7 +28,7 @@ module.exports = class ColonAssignmentSpacing
             class Cat
               canBark: false
             </code></pre>
-            """
+            '''
 
     tokens: [':']
 

--- a/src/rules/cyclomatic_complexity.coffee
+++ b/src/rules/cyclomatic_complexity.coffee
@@ -5,7 +5,9 @@ module.exports = class CyclomaticComplexity
         level: 'ignore'
         message: 'The cyclomatic complexity is too damn high'
         value: 10
-        description: 'Examine the complexity of your application.'
+        description: '''
+            Examine the complexity of your application.
+            '''
 
     # returns the "complexity" value of the current node.
     getComplexity: (node) ->

--- a/src/rules/duplicate_key.coffee
+++ b/src/rules/duplicate_key.coffee
@@ -9,8 +9,9 @@ module.exports = class DuplicateKey
         name: 'duplicate_key'
         level: 'error'
         message: 'Duplicate key defined in object or class'
-        description:
-            "Prevents defining duplicate keys in object literals and classes"
+        description: '''
+            Prevents defining duplicate keys in object literals and classes
+            '''
 
     tokens: [ 'IDENTIFIER', '{', '}' ]
 

--- a/src/rules/empty_constructor_needs_parens.coffee
+++ b/src/rules/empty_constructor_needs_parens.coffee
@@ -5,8 +5,9 @@ module.exports = class EmptyConstructorNeedsParens
         name: 'empty_constructor_needs_parens'
         level: 'ignore'
         message: 'Invoking a constructor without parens and without arguments'
-        description:
-            "Requires constructors with no parameters to include the parens"
+        description: '''
+            Requires constructors with no parameters to include the parens
+            '''
 
     tokens: [ 'UNARY' ]
 

--- a/src/rules/ensure_comprehensions.coffee
+++ b/src/rules/ensure_comprehensions.coffee
@@ -4,8 +4,9 @@ module.exports = class EnsureComprehensions
         name: 'ensure_comprehensions'
         level: 'warn'
         message: 'Comprehensions must have parentheses around them'
-        description:
-            'This rule makes sure that parentheses are around comprehensions.'
+        description: '''
+            This rule makes sure that parentheses are around comprehensions.
+            '''
 
     tokens: ['FOR']
 

--- a/src/rules/eol_last.coffee
+++ b/src/rules/eol_last.coffee
@@ -4,7 +4,9 @@ module.exports = class EOLLast
         name: 'eol_last'
         level: 'ignore'
         message: 'File does not end with a single newline'
-        description: "Checks that the file ends with a single newline"
+        description: '''
+            Checks that the file ends with a single newline
+            '''
 
     lintLine: (line, lineApi) ->
         return null unless lineApi.isLastLine()

--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -5,7 +5,7 @@ module.exports = class Indentation
         value: 2
         level: 'error'
         message: 'Line contains inconsistent indentation'
-        description: """
+        description: '''
             This rule imposes a standard number of spaces to be used for
             indentation. Since whitespace is significant in CoffeeScript, it's
             critical that a project chooses a standard indentation format and
@@ -20,7 +20,7 @@ module.exports = class Indentation
             </code>
             </pre>
             Two space indentation is enabled by default.
-            """
+            '''
 
     tokens: ['INDENT', '[', ']', '.']
 

--- a/src/rules/line_endings.coffee
+++ b/src/rules/line_endings.coffee
@@ -5,10 +5,10 @@ module.exports = class LineEndings
         level: 'ignore'
         value: 'unix' # or 'windows'
         message: 'Line contains incorrect line endings'
-        description: """
+        description: '''
             This rule ensures your project uses only <tt>windows</tt> or
             <tt>unix</tt> line endings. This rule is disabled by default.
-            """
+            '''
 
     lintLine: (line, lineApi) ->
         ending = lineApi.config[@rule.name]?.value

--- a/src/rules/max_line_length.coffee
+++ b/src/rules/max_line_length.coffee
@@ -17,14 +17,14 @@ module.exports = class MaxLineLength
         level: 'error'
         limitComments: true
         message: 'Line exceeds maximum allowed length'
-        description: """
+        description: '''
             This rule imposes a maximum line length on your code. <a
             href="http://www.python.org/dev/peps/pep-0008/">Python's style
             guide</a> does a good job explaining why you might want to limit the
             length of your lines, though this is a matter of taste.
 
             Lines can be no longer than eighty characters by default.
-            """
+            '''
 
     lintLine: (line, lineApi) ->
         max = lineApi.config[@rule.name]?.value

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -17,8 +17,7 @@ module.exports = class MissingFatArrows
         level: 'ignore'
         is_strict: false
         message: 'Used `this` in a function without a fat arrow'
-        description:
-            '''
+        description: '''
             Warns when you use `this` inside a function that wasn't defined
             with a fat arrow. This rule does not apply to methods defined in a
             class, since they have `this` bound to the class instance (or the

--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -5,13 +5,13 @@ module.exports = class NewlinesAfterClasses
         value: 3
         level: 'ignore'
         message: 'Wrong count of newlines between a class and other code'
-        description: """
-        <p>Checks the number of newlines between classes and other code.</p>
+        description: '''
+            <p>Checks the number of newlines between classes and other code.</p>
 
-        Options:
-        - <pre><code>value</code></pre> - The number of required newlines
-        after class definitions. Defaults to 3.
-        """
+            Options:
+            - <pre><code>value</code></pre> - The number of required newlines
+            after class definitions. Defaults to 3.
+            '''
 
     tokens: ['CLASS', '}', '{']
 

--- a/src/rules/no_backticks.coffee
+++ b/src/rules/no_backticks.coffee
@@ -4,16 +4,16 @@ module.exports = class NoBackticks
         name: 'no_backticks'
         level: 'error'
         message: 'Backticks are forbidden'
-        description: """
+        description: '''
             Backticks allow snippets of JavaScript to be embedded in
             CoffeeScript. While some folks consider backticks useful in a few
             niche circumstances, they should be avoided because so none of
             JavaScript's "bad parts", like <tt>with</tt> and <tt>eval</tt>,
             sneak into CoffeeScript.
             This rule is enabled by default.
-            """
+            '''
 
-    tokens: [ "JS" ]
+    tokens: [ 'JS' ]
 
     lintToken: (token, tokenApi) ->
         true

--- a/src/rules/no_debugger.coffee
+++ b/src/rules/no_debugger.coffee
@@ -6,12 +6,12 @@ module.exports = class NoDebugger
         level: 'warn'
         message: 'Found debugging code'
         console: false
-        description: """
+        description: '''
             This rule detects `debugger` and optionally `console` calls
             This rule is `warn` by default.
-            """
+            '''
 
-    tokens: [ "DEBUGGER", "IDENTIFIER" ]
+    tokens: [ 'DEBUGGER', 'IDENTIFIER' ]
 
     lintToken: (token, tokenApi) ->
         if token[0] is 'DEBUGGER'

--- a/src/rules/no_empty_functions.coffee
+++ b/src/rules/no_empty_functions.coffee
@@ -8,7 +8,7 @@ module.exports = class NoEmptyFunctions
         name: 'no_empty_functions'
         level: 'ignore'
         message: 'Empty function'
-        description: """
+        description: '''
             Disallows declaring empty functions. The goal of this rule is that
             unintentional empty callbacks can be detected:
             <pre>
@@ -31,7 +31,7 @@ module.exports = class NoEmptyFunctions
             doSomethingSignificant()
             </code>
             </pre>
-            """
+            '''
 
     lintAST: (node, astApi) ->
         @lintNode node, astApi

--- a/src/rules/no_empty_param_list.coffee
+++ b/src/rules/no_empty_param_list.coffee
@@ -1,12 +1,10 @@
-
-
 module.exports = class NoEmptyParamList
 
     rule:
         name: 'no_empty_param_list'
         level: 'ignore'
         message: 'Empty parameter list is forbidden'
-        description: """
+        description: '''
             This rule prohibits empty parameter lists in function definitions.
             <pre>
             <code># The empty parameter list in here is unnecessary:
@@ -17,9 +15,9 @@ module.exports = class NoEmptyParamList
             </code>
             </pre>
             Empty parameter lists are permitted by default.
-            """
+            '''
 
-    tokens: [ "PARAM_START" ]
+    tokens: [ 'PARAM_START' ]
 
     lintToken: (token, tokenApi) ->
         nextType = tokenApi.peek()[0]

--- a/src/rules/no_implicit_braces.coffee
+++ b/src/rules/no_implicit_braces.coffee
@@ -22,7 +22,7 @@ module.exports = class NoImplicitBraces
             </pre>
             Implicit braces are permitted by default, since their use is
             idiomatic CoffeeScript.
-        '''
+            '''
 
     tokens: ['{', 'OUTDENT', 'CLASS', 'IDENTIFIER']
 
@@ -43,7 +43,7 @@ module.exports = class NoImplicitBraces
                 (not @className? or tokenApi.peek(-1)[0] is 'EXTENDS')
             @className = val
 
-        if token.generated and type is "{"
+        if token.generated and type is '{'
             # If strict mode is turned off it allows implicit braces when the
             # object is declared over multiple lines.
             unless tokenApi.config[@rule.name].strict

--- a/src/rules/no_implicit_parens.coffee
+++ b/src/rules/no_implicit_parens.coffee
@@ -5,7 +5,7 @@ module.exports = class NoImplicitParens
         level: 'ignore'
         message: 'Implicit parens are forbidden'
         strict: true
-        description: """
+        description: '''
             This rule prohibits implicit parens on function calls.
             <pre>
             <code># Some folks don't like this style of coding.
@@ -17,7 +17,7 @@ module.exports = class NoImplicitParens
             </pre>
             Implicit parens are permitted by default, since their use is
             idiomatic CoffeeScript.
-            """
+            '''
 
 
     tokens: ['CALL_END']

--- a/src/rules/no_plusplus.coffee
+++ b/src/rules/no_plusplus.coffee
@@ -5,15 +5,15 @@ module.exports = class NoPlusPlus
         name: 'no_plusplus'
         level: 'ignore'
         message: 'The increment and decrement operators are forbidden'
-        description: """
+        description: '''
             This rule forbids the increment and decrement arithmetic operators.
             Some people believe the <tt>++</tt> and <tt>--</tt> to be cryptic
             and the cause of bugs due to misunderstandings of their precedence
             rules.
             This rule is disabled by default.
-            """
+            '''
 
-    tokens: [ "++", "--" ]
+    tokens: [ '++', '--' ]
 
     lintToken: (token, tokenApi) ->
         return {context: "found '#{token[0]}'"}

--- a/src/rules/no_private_function_fat_arrows.coffee
+++ b/src/rules/no_private_function_fat_arrows.coffee
@@ -5,11 +5,11 @@ module.exports = class NoPrivateFunctionFatArrows
         name: 'no_private_function_fat_arrows'
         level: 'warn'
         message: 'Used the fat arrow for a private function'
-        description: """
+        description: '''
             Warns when you use the fat arrow for a private function
             inside a class definition scope. It is not necessary and
             it does not do anything.
-            """
+            '''
 
     lintAST: (node, @astApi) ->
         @lintNode node

--- a/src/rules/no_stand_alone_at.coffee
+++ b/src/rules/no_stand_alone_at.coffee
@@ -4,8 +4,7 @@ module.exports = class NoStandAloneAt
         name: 'no_stand_alone_at'
         level: 'ignore'
         message: '@ must not be used stand alone'
-        description:
-            '''
+        description: '''
             This rule checks that no stand alone @ are in use, they are
             discouraged. Further information in CoffeScript issue <a
             href="https://github.com/jashkenas/coffee-script/issues/1601">

--- a/src/rules/no_tabs.coffee
+++ b/src/rules/no_tabs.coffee
@@ -5,10 +5,10 @@ module.exports = class NoTabs
         name: 'no_tabs'
         level: 'error'
         message: 'Line contains tab indentation'
-        description: """
+        description: '''
             This rule forbids tabs in indentation. Enough said. It is enabled by
             default.
-            """
+            '''
 
     lintLine: (line, lineApi) ->
         # Only check lines that have compiled tokens. This helps

--- a/src/rules/no_this.coffee
+++ b/src/rules/no_this.coffee
@@ -3,8 +3,7 @@ module.exports = class NoThis
         name: 'no_this'
         level: 'ignore'
         message: "Don't use 'this', use '@' instead"
-        description:
-            '''
+        description: '''
             This rule prohibits 'this'.
             Use '@' instead.
             '''

--- a/src/rules/no_throwing_strings.coffee
+++ b/src/rules/no_throwing_strings.coffee
@@ -4,7 +4,7 @@ module.exports = class NoThrowingStrings
         name: 'no_throwing_strings'
         level: 'error'
         message: 'Throwing strings is forbidden'
-        description: """
+        description: '''
             This rule forbids throwing string literals or interpolations. While
             JavaScript (and CoffeeScript by extension) allow any expression to
             be thrown, it is best to only throw <a
@@ -23,7 +23,7 @@ module.exports = class NoThrowingStrings
             </code>
             </pre>
             This rule is enabled by default.
-            """
+            '''
 
     tokens: [ 'THROW' ]
 

--- a/src/rules/no_trailing_semicolons.coffee
+++ b/src/rules/no_trailing_semicolons.coffee
@@ -7,7 +7,7 @@ module.exports = class NoTrailingSemicolons
         name: 'no_trailing_semicolons'
         level: 'error'
         message: 'Line contains a trailing semicolon'
-        description: """
+        description: '''
             This rule prohibits trailing semicolons, since they are needless
             cruft in CoffeeScript.
             <pre>
@@ -19,8 +19,7 @@ module.exports = class NoTrailingSemicolons
             </code>
             </pre>
             Trailing semicolons are forbidden by default.
-            """
-
+            '''
 
     lintLine: (line, lineApi) ->
 

--- a/src/rules/no_trailing_whitespace.coffee
+++ b/src/rules/no_trailing_whitespace.coffee
@@ -12,10 +12,10 @@ module.exports = class NoTrailingWhitespace
         message: 'Line ends with trailing whitespace'
         allowed_in_comments: false
         allowed_in_empty_lines: true
-        description: """
+        description: '''
             This rule forbids trailing whitespace in your code, since it is
             needless cruft. It is enabled by default.
-            """
+            '''
 
     lintLine: (line, lineApi) ->
         unless lineApi.config['no_trailing_whitespace']?.allowed_in_empty_lines

--- a/src/rules/no_unnecessary_fat_arrows.coffee
+++ b/src/rules/no_unnecessary_fat_arrows.coffee
@@ -6,10 +6,10 @@ module.exports = class NoUnnecessaryFatArrows
         name: 'no_unnecessary_fat_arrows'
         level: 'warn'
         message: 'Unnecessary fat arrow'
-        description: """
+        description: '''
             Disallows defining functions with fat arrows when `this`
             is not used within the function.
-            """
+            '''
 
     lintAST: (node, @astApi) ->
         @lintNode node

--- a/src/rules/non_empty_constructor_needs_parens.coffee
+++ b/src/rules/non_empty_constructor_needs_parens.coffee
@@ -7,8 +7,9 @@ module.exports = class NonEmptyConstructorNeedsParens extends ParentClass
         name: 'non_empty_constructor_needs_parens'
         level: 'ignore'
         message: 'Invoking a constructor without parens and with arguments'
-        description:
-            "Requires constructors with parameters to include the parens"
+        description: '''
+            Requires constructors with parameters to include the parens
+            '''
 
     handleExpectedCallStart: (expectedCallStart) ->
         if expectedCallStart[0] is 'CALL_START' and expectedCallStart.generated

--- a/src/rules/prefer_english_operator.coffee
+++ b/src/rules/prefer_english_operator.coffee
@@ -2,14 +2,14 @@
 module.exports = class PreferEnglishOperator
     rule:
         name: 'prefer_english_operator'
-        description: '''
-        This rule prohibits &&, ||, ==, != and !.
-        Use and, or, is, isnt, and not instead.
-        !! for converting to a boolean is ignored.
-        '''
         level: 'ignore'
-        doubleNotLevel: 'ignore'
         message: 'Don\'t use &&, ||, ==, !=, or !'
+        doubleNotLevel: 'ignore'
+        description: '''
+            This rule prohibits &&, ||, ==, != and !.
+            Use and, or, is, isnt, and not instead.
+            !! for converting to a boolean is ignored.
+            '''
 
     tokens: ['COMPARE', 'UNARY_MATH', 'LOGIC']
     lintToken: (token, tokenApi) ->

--- a/src/rules/space_operators.coffee
+++ b/src/rules/space_operators.coffee
@@ -5,7 +5,9 @@ module.exports = class SpaceOperators
         name: 'space_operators'
         level: 'ignore'
         message: 'Operators must be spaced properly'
-        description: "This rule enforces that operators have space around them."
+        description: '''
+            This rule enforces that operators have spaces around them.
+            '''
 
     tokens: ['+', '-', '=', '**', 'MATH', 'COMPARE', 'LOGIC', 'COMPOUND_ASSIGN',
         'STRING_START', 'STRING_END', 'CALL_START', 'CALL_END']

--- a/src/rules/spacing_after_comma.coffee
+++ b/src/rules/spacing_after_comma.coffee
@@ -2,9 +2,11 @@
 module.exports = class SpacingAfterComma
     rule:
         name: 'spacing_after_comma'
-        description: 'This rule requires a space after commas.'
         level: 'ignore'
-        message: 'Spaces are required after commas'
+        message: 'a space is required after commas'
+        description: '''
+            This rule checks to make sure you have a space after commas.
+            '''
 
     tokens: [',', 'REGEX_START', 'REGEX_END']
 

--- a/src/rules/transform_messes_up_line_numbers.coffee
+++ b/src/rules/transform_messes_up_line_numbers.coffee
@@ -5,11 +5,10 @@ module.exports = class TransformMessesUpLineNumbers
         name: 'transform_messes_up_line_numbers'
         level: 'warn'
         message: 'Transforming source messes up line numbers'
-        description:
-            """
+        description: '''
             This rule detects when changes are made by transform function,
             and warns that line numbers are probably incorrect.
-            """
+            '''
 
     tokens: []
 

--- a/test/fixtures/mock_node_modules/he_who_must_not_be_named/he_who_must_not_be_named.coffee
+++ b/test/fixtures/mock_node_modules/he_who_must_not_be_named/he_who_must_not_be_named.coffee
@@ -5,9 +5,8 @@ module.exports = class HeWhoMustNotBeNamed
     rule:
         name: 'he_who_must_not_be_named'
         level: 'error'
-        message: "Forbidden variable name. The snatchers have been alerted"
-        description: """
-        """
+        message: 'Forbidden variable name. The snatchers have been alerted'
+        description: ''
 
     tokens: [ 'IDENTIFIER' ]
 

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -6,8 +6,7 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('arrows').addBatch({
 
     'No spacing around the arrow operator':
-
-        topic: ->
+        topic:
             '''
             test1 = (foo, bar)->console.log("foobar")
             test2 = (foo, bar) ->console.log("foo->bar")
@@ -27,8 +26,8 @@ vows.describe('arrows').addBatch({
 
         'will return an error': (source) ->
             config = {
-                "indentation": { "value": 2, "level": "error" }
-                "arrow_spacing": { "level": "error" }
+                'indentation': { 'value': 2, 'level': 'error' }
+                'arrow_spacing': { 'level': 'error' }
             }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 8)
@@ -42,13 +41,12 @@ vows.describe('arrows').addBatch({
             assert.equal(errors[7].lineNumber, 11)
 
         'will be ignored (no error)': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
     'Handles good spacing when parentheses are generated':
-
-        topic: ->
+        topic:
             '''
             testingThis
               .around ->
@@ -71,23 +69,22 @@ vows.describe('arrows').addBatch({
 
         'when spacing is not required around arrow operator': (source) ->
             config = {
-                "indentation": { "value": 2, "level": "error" },
-                "arrow_spacing": { "level": "ignore" }
+                'indentation': { 'value': 2, 'level': 'error' },
+                'arrow_spacing': { 'level': 'ignore' }
             }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
         'when spacing is required around arrow operator': (source) ->
             config = {
-                "indentation": { "value": 2, "level": "error" },
-                "arrow_spacing": { "level": "error" }
+                'indentation': { 'value': 2, 'level': 'error' },
+                'arrow_spacing': { 'level': 'error' }
             }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
     'Handles bad spacing when parentheses are generated':
-
-        topic: ->
+        topic:
             '''
             testingThis
               .around ->
@@ -108,7 +105,7 @@ vows.describe('arrows').addBatch({
             '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors[0].lineNumber, 3)
             assert.equal(errors[1].lineNumber, 6)
@@ -120,14 +117,14 @@ vows.describe('arrows').addBatch({
             assert.equal(errors.length, 7)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
     'Ignore spacing for non-generated parentheses':
         # if the function has no parameters (and thus no parentheses),
         # it will accept a lack of spacing preceding the arrow (first example)
-        topic: ->
+        topic:
             '''
             x(-> 3)
             x( -> 3)
@@ -135,17 +132,17 @@ vows.describe('arrows').addBatch({
             (-> true)()
             '''
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handle an arrow at beginning of statement':
-        topic: ->
+        topic:
             '''
             @waitForSelector ".application",
               -> @test.pass "homepage loaded ok"
@@ -154,17 +151,17 @@ vows.describe('arrows').addBatch({
             '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handle an empty arrow at end of expression':
-        topic: ->
+        topic:
             '''
             (x = ->)
             {x: ->}
@@ -172,76 +169,87 @@ vows.describe('arrows').addBatch({
             '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handle a nested arrow at end of file':
-        topic: ->
-            'class A\n  f: ->'
+        topic:
+            '''
+            class A\n  f: ->
+            '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handle a nested arrow at end of file':
-        topic: ->
-            'define ->\n  class A\n    f: ->'
+        topic:
+            '''
+            define ->\n  class A\n    f: ->
+            '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handle an arrow at end of file':
-        topic: ->
-            'f: ->'
+        topic:
+            '''
+            f: ->
+            '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
     'Handles empty functions':
-        topic: "console ?= log: (->), error: (->)"
+        topic:
+            '''
+            console ?= log: (->), error: (->)
+            '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
     'Handle an arrow at beginning of file':
-        topic: ->
-            '-> foo()'
+        topic:
+            '''
+            -> foo()
+            '''
 
         'when spacing is required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "error" } }
+            config = { 'arrow_spacing': { 'level': 'error' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'when spacing is not required around arrow operator': (source) ->
-            config = { "arrow_spacing": { "level": "ignore" } }
+            config = { 'arrow_spacing': { 'level': 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -32,8 +32,8 @@ sources =
                       bar  } = x
                    '''
     stringInterpolation:
-        noSpaces: "\"\#{foo}\""
-        oneSpace: "\"\#{ foo }\""
+        noSpaces: '"\#{foo}"'
+        oneSpace: '"\#{ foo }"'
 
     fnImplicitParens:
         '''
@@ -49,9 +49,9 @@ sources =
 
 configs =
     oneEmptyObjectSpace:
-        braces_spacing: {level: 'error', empty_object_spaces: 1}
+        braces_spacing: { level: 'error', empty_object_spaces: 1 }
     oneSpace:
-        braces_spacing: {level: 'error', spaces: 1}
+        braces_spacing: { level: 'error', spaces: 1 }
     zeroEmptyObjectSpaces:
         braces_spacing: {level: 'error', empty_object_spaces: 0}
     zeroSpaces:

--- a/test/test_camel_case_classes.coffee
+++ b/test/test_camel_case_classes.coffee
@@ -7,8 +7,8 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('identifiers').addBatch({
 
     'Camel cased class names':
-
-        topic: -> """
+        topic:
+            '''
             class Animal
 
             class Wolf extends Animal
@@ -24,14 +24,15 @@ vows.describe('identifiers').addBatch({
             class nested.Name
 
             class deeply.nested.Name
-            """
+            '''
 
         'are valid by default': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Non camel case class names':
-        topic: """
+        topic:
+            '''
             class animal
 
             class wolf extends Animal
@@ -41,7 +42,7 @@ vows.describe('identifiers').addBatch({
             class canadaGoose extends Animal
 
             class _PrivatePrefix
-            """
+            '''
 
         'are rejected by default': (source) ->
             errors = coffeelint.lint(source)
@@ -59,7 +60,8 @@ vows.describe('identifiers').addBatch({
             assert.isEmpty(errors)
 
     'Anonymous class names':
-        topic: """
+        topic:
+            '''
             x = class
               m : -> 123
 
@@ -69,14 +71,15 @@ vows.describe('identifiers').addBatch({
             z = class
 
             r = class then 1:2
-            """
+            '''
 
         'are permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Inner classes are permitted':
-        topic: '''
+        topic:
+            '''
             class X
               class @Y
                 f : 123

--- a/test/test_coffeelint.coffee
+++ b/test/test_coffeelint.coffee
@@ -13,10 +13,10 @@ vows.describe('coffeelint').addBatch({
             assert.isString(version)
 
     "CoffeeLint's errors":
-        topic: () -> coffeelint.lint """
+        topic: () -> coffeelint.lint '''
             a = () ->\t
                 1234
-            """
+            '''
 
         'are sorted by line number': (errors) ->
             assert.isArray(errors)
@@ -25,12 +25,13 @@ vows.describe('coffeelint').addBatch({
             assert.equal(errors[0].lineNumber, 1)
 
     'Errors in the source':
-        topic: '''
+        topic:
+            '''
             fruits = [orange, apple, banana]
             switch 'a'
               when in fruits
                 something
-        '''
+            '''
 
         'are reported': (source) ->
             errors = coffeelint.lint(source)
@@ -43,7 +44,7 @@ vows.describe('coffeelint').addBatch({
             if error.message.indexOf('on line') isnt -1
                 m = "Error: Parse error on line 3: Unexpected 'RELATION'"
             else if error.message.indexOf('SyntaxError:') isnt -1
-                m = "SyntaxError: unexpected RELATION"
+                m = 'SyntaxError: unexpected RELATION'
             else
                 # CoffeeLint changed the format to be more complex.  I don't
                 # think an exact match really needs to be verified.

--- a/test/test_colon_assignment_spacing.coffee
+++ b/test/test_colon_assignment_spacing.coffee
@@ -7,7 +7,7 @@ vows.describe('colon_assignment_spacing').addBatch({
 
 
     'Equal spacing around assignment':
-        topic: ->
+        topic:
             '''
             object = {spacing : true}
             class Dog
@@ -27,7 +27,7 @@ vows.describe('colon_assignment_spacing').addBatch({
             assert.isEmpty(errors)
 
     'No space before assignment':
-        topic: ->
+        topic:
             '''
             object = {spacing: true}
             object =
@@ -49,12 +49,12 @@ vows.describe('colon_assignment_spacing').addBatch({
             assert.isEmpty(errors)
 
     'Newline to the right of assignment':
-        topic: ->
-            """
+        topic:
+            '''
             query:
               method: 'GET'
               isArray: false
-            """
+            '''
 
         'will not return an error': (source) ->
             config =
@@ -67,7 +67,7 @@ vows.describe('colon_assignment_spacing').addBatch({
             assert.isEmpty(errors)
 
     'Improper spacing around assignment':
-        topic: ->
+        topic:
             '''
             object = {spacing: false}
             class Cat
@@ -97,7 +97,7 @@ vows.describe('colon_assignment_spacing').addBatch({
             assert.isEmpty(errors)
 
     'Should not complain about strings':
-        topic: ->
+        topic:
             '''
             foo = (stuff) ->
               throw new Error("Error: stuff required") unless stuff?

--- a/test/test_commandline.coffee
+++ b/test/test_commandline.coffee
@@ -19,20 +19,20 @@ execOptions =
 # args. Callback will be called with (error, stdout,
 # stderr)
 commandline = (args, callback) ->
-    exec("#{coffeelintPath} #{args.join(" ")}", execOptions, callback)
+    exec("#{coffeelintPath} #{args.join(' ')}", execOptions, callback)
 
 
-process.env.HOME = ""
-process.env.HOMEPATH = ""
-process.env.USERPROFILE = ""
-process.env.COFFEELINT_CONFIG = ""
+process.env.HOME = ''
+process.env.HOMEPATH = ''
+process.env.USERPROFILE = ''
+process.env.COFFEELINT_CONFIG = ''
 
 # Custom rules are loaded by module name. Using a relative path in the test is
 # an unrealistic example when rules can be installed with `npm install -g
 # some-custom-rule`. This will setup a fake version of node_modules to a
 # relative path doesn't have to be used.
-process.env.NODE_PATH += ":" + path.resolve( __dirname,
-    "fixtures/mock_node_modules/")
+process.env.NODE_PATH += ':' + path.resolve( __dirname,
+    'fixtures/mock_node_modules/')
 
 vows.describe('commandline').addBatch({
 
@@ -44,12 +44,12 @@ vows.describe('commandline').addBatch({
         'shows usage': (error, stdout, stderr) ->
             assert.isNotNull(error)
             assert.notEqual(error.code, 0)
-            assert.include(stderr, "Usage")
+            assert.include(stderr, 'Usage')
             assert.isEmpty(stdout)
 
     'version':
         topic: () ->
-            commandline ["--version"], this.callback
+            commandline ['--version'], this.callback
             return undefined
 
         'exists': (error, stdout, stderr) ->
@@ -139,7 +139,7 @@ vows.describe('commandline').addBatch({
                 # It's up to NodeJS to resolve the actual path. The top of the
                 # file modifies NODE_PATH so this can look like a 3rd party
                 # module.
-                "he_who_must_not_be_named"
+                'he_who_must_not_be_named'
                 'fixtures/custom_rules/voldemort.coffee'
             ]
 
@@ -321,9 +321,8 @@ vows.describe('commandline').addBatch({
 
         'Autoloads config based on cwd':
             topic: () ->
-                exec("cat fixtures/cyclo_fail.coffee |" +
-                    " #{coffeelintPath} --stdin",
-                    execOptions, this.callback)
+                exec('cat fixtures/cyclo_fail.coffee | ' +
+                    coffeelintPath + ' --stdin', execOptions, this.callback)
                 return undefined
 
             'fails': (error, stdout, stderr) ->
@@ -395,7 +394,7 @@ vows.describe('commandline').addBatch({
                 args = [
                     'fixtures/clean.coffee'
                 ]
-                process.env.COFFEELINT_CONFIG = "not_existing_293ujff"
+                process.env.COFFEELINT_CONFIG = 'not_existing_293ujff'
                 commandline args, this.callback
                 return undefined
 
@@ -407,7 +406,7 @@ vows.describe('commandline').addBatch({
                 args = [
                     'fixtures/fourspaces.coffee'
                 ]
-                conf = "fixtures/fourspaces.json"
+                conf = 'fixtures/fourspaces.json'
                 process.env.COFFEELINT_CONFIG = conf
                 commandline args, this.callback
                 return undefined
@@ -421,7 +420,7 @@ vows.describe('commandline').addBatch({
                     '--noconfig'
                     'fixtures/fourspaces.coffee'
                 ]
-                conf = "fixtures/fourspaces.json"
+                conf = 'fixtures/fourspaces.json'
                 process.env.COFFEELINT_CONFIG = conf
                 commandline args, this.callback
                 return undefined

--- a/test/test_comment_config.coffee
+++ b/test/test_comment_config.coffee
@@ -7,13 +7,13 @@ vows.describe('comment config').addBatch({
 
     'Disable statements':
         topic: () ->
-            """
+            '''
             # coffeelint: disable=no_trailing_semicolons
             a 'you get a semi-colon';
             b 'you get a semi-colon';
             # coffeelint: enable=no_trailing_semicolons
             c 'everybody gets a semi-colon';
-            """
+            '''
 
         'can disable rules in your config': (source) ->
             config =
@@ -23,13 +23,13 @@ vows.describe('comment config').addBatch({
 
     'Enable statements':
         topic: () ->
-            """
+            '''
             # coffeelint: enable=no_implicit_parens
             a 'implicit parens here'
             b 'implicit parens', 'also here'
             # coffeelint: disable=no_implicit_parens
             c 'implicit parens allowed here'
-            """
+            '''
 
         'can enable rules not in your config': (source) ->
             errors = coffeelint.lint(source)
@@ -37,13 +37,13 @@ vows.describe('comment config').addBatch({
 
     'Enable all statements':
         topic: () ->
-            """
+            '''
             # coffeelint: disable=no_trailing_semicolons,no_implicit_parens
             a 'you get a semi-colon';
             b 'you get a semi-colon';
             # coffeelint: enable
             c 'everybody gets a semi-colon';
-            """
+            '''
 
         'will re-enable all rules in your config': (source) ->
             config =

--- a/test/test_cyclomatic_complexity.coffee
+++ b/test/test_cyclomatic_complexity.coffee
@@ -17,13 +17,14 @@ getComplexity = (source) ->
 vows.describe('cyclomatic complexity').addBatch({
 
     'Cyclomatic complexity':
-        topic: """
+        topic:
+            '''
             x = ->
               1 and 2 and 3 and
               4 and 5 and 6 and
               7 and 8 and 9 and
               10 and 11
-            """
+            '''
 
         'defaults to ignore': (source) ->
             errors = coffeelint.lint(source)
@@ -48,14 +49,20 @@ vows.describe('cyclomatic complexity').addBatch({
             assert.isEmpty(errors)
 
     'An empty function':
-        topic: "x = () -> 1234"
+        topic:
+            '''
+            x = () -> 1234
+            '''
 
         'has a complexity of one': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 1)
 
     'If statement':
-        topic: "x = () -> 2 if $ == true"
+        topic:
+            '''
+            x = () -> 2 if $ == true
+            '''
 
         'increments the complexity': (source) ->
             complexity = getComplexity(source)
@@ -64,27 +71,32 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'If Else statement':
-        topic: 'y = -> if $ then 1 else 3'
+        topic:
+            '''
+            y = -> if $ then 1 else 3
+            '''
 
         'increments the complexity': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 2)
 
     'If ElseIf statement':
-        topic: """
+        topic:
+            '''
             x = ->
               if 1233
                 'abc'
               else if 456
                 'xyz'
-            """
+            '''
 
         'has a complexity of three': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 3)
 
     'If If-Else Else statement':
-        topic: """
+        topic:
+            '''
             z = () ->
               if x
                 1
@@ -92,7 +104,7 @@ vows.describe('cyclomatic complexity').addBatch({
                 2
               else
                 3
-            """
+            '''
 
         'has a complexity of three': (source) ->
             complexity = getComplexity(source)
@@ -100,12 +112,13 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'Nested if statements':
-        topic: """
+        topic:
+            '''
             z = () ->
               if abc?
                 if other?
                   123
-            """
+            '''
 
         'has a complexity of three': (source) ->
             complexity = getComplexity(source)
@@ -114,18 +127,22 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'A while loop':
-        topic: """
+        topic:
+            '''
             x = () ->
               while 1
                 'asdf'
-            """
+            '''
         'increments complexity': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 2)
 
 
     'An until loop':
-        topic: "x = () -> log 'a' until $?"
+        topic:
+            '''
+            x = () -> log 'a' until $?
+            '''
 
         'increments complexity': (source) ->
             complexity = getComplexity(source)
@@ -133,18 +150,22 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'A for loop':
-        topic: """
+        topic:
+            '''
             x = () ->
               for i in window
                 log i
-            """
+            '''
 
         'increments complexity': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 2)
 
     'A list comprehension':
-        topic: "x = -> [a for a in window]"
+        topic:
+            '''
+            x = -> [a for a in window]
+            '''
 
         'increments complexity': (source) ->
             complexity = getComplexity(source)
@@ -152,20 +173,22 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'Try / Catch blocks':
-        topic: """
+        topic:
+            '''
             x = () ->
               try
                 divide("byZero")
               catch error
                 log("uh oh")
-            """
+            '''
 
         'increments complexity': (source) ->
             assert.equal(getComplexity(source), 2)
 
 
     'Try / Catch / Finally blocks':
-        topic: """
+        topic:
+            '''
             x = () ->
               try
                 divide("byZero")
@@ -173,14 +196,15 @@ vows.describe('cyclomatic complexity').addBatch({
                 log("uh oh")
               finally
                 clean()
-            """
+            '''
 
         'increments complexity': (source) ->
             assert.equal(getComplexity(source), 2)
 
 
     'Switch statements without an else':
-        topic: '''
+        topic:
+            '''
             x = () ->
               switch a
                 when "b" then "b"
@@ -194,7 +218,8 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'Switch statements with an else':
-        topic: '''
+        topic:
+            '''
             x = () ->
               switch a
                 when "b" then "b"
@@ -209,15 +234,20 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'And operators':
-        topic: 'x = () -> $ and window'
+        topic:
+            '''
+            x = () -> $ and window
+            '''
 
         'increments the complexity': (source) ->
             complexity = getComplexity(source)
             assert.equal(complexity, 2)
 
     'Or operators':
-
-        topic: 'x = () -> $ or window'
+        topic:
+            '''
+            x = () -> $ or window
+            '''
 
         'increments the complexity': (source) ->
             complexity = getComplexity(source)
@@ -225,7 +255,8 @@ vows.describe('cyclomatic complexity').addBatch({
 
 
     'A complicated example':
-        topic: """
+        topic:
+            '''
             x = () ->
               if a and b and c or d and c or e
                 if x or d or e of f
@@ -236,7 +267,7 @@ vows.describe('cyclomatic complexity').addBatch({
               while false
                 y
               return false
-            """
+            '''
 
         'works': (source) ->
             config = {cyclomatic_complexity: {level: 'error'}}

--- a/test/test_duplicate_key.coffee
+++ b/test/test_duplicate_key.coffee
@@ -29,7 +29,7 @@ vows.describe(RULE).addBatch({
 
         'should error by default': (source) ->
             # Moved to a variable to avoid lines being too long.
-            message = "Duplicate key defined in object or class"
+            message = 'Duplicate key defined in object or class'
             errors = coffeelint.lint(source)
             # Verify the two actual duplicate keys are found and it is not
             # mistaking @getConfig as a duplicate key

--- a/test/test_empty_constructor_needs_parens.coffee
+++ b/test/test_empty_constructor_needs_parens.coffee
@@ -5,12 +5,14 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 vows.describe('empty_constructor_needs_parens').addBatch({
 
-    '#421':
-        topic: '''
-        new OPERATIONS[operationSpec.type] operationSpec.field
 
-        new Foo[bar].baz[qux] param1
-        '''
+    'Make sure no errors if constructors are indexed (#421)':
+        topic:
+            '''
+            new OPERATIONS[operationSpec.type] operationSpec.field
+
+            new Foo[bar].baz[qux] param1
+            '''
 
         'should pass': (source) ->
             config =
@@ -20,8 +22,8 @@ vows.describe('empty_constructor_needs_parens').addBatch({
             assert.equal(errors.length, 0)
 
     'Missing Parentheses on "new Foo"':
-        topic: () ->
-            """
+        topic:
+            '''
             class Foo
 
             # Warn about missing parens here
@@ -35,7 +37,7 @@ vows.describe('empty_constructor_needs_parens').addBatch({
             # Since this does have a parameter it should not require parens
             g = new bar.foo.Foo
               config: 'parameter'
-            """
+            '''
 
         'warns about missing parens': (source) ->
             config =

--- a/test/test_indentation.coffee
+++ b/test/test_indentation.coffee
@@ -7,14 +7,14 @@ vows.describe('indent').addBatch({
 
     'Indentation':
 
-        topic: () ->
-            """
+        topic:
+            '''
             x = () ->
               'two spaces'
 
             a = () ->
                 'four spaces'
-            """
+            '''
 
         'defaults to two spaces': (source) ->
             errors = coffeelint.lint(source)
@@ -45,12 +45,12 @@ vows.describe('indent').addBatch({
             assert.equal(errors.length, 0)
 
     'Nested indentation errors':
-        topic: () ->
-            """
+        topic:
+            '''
             x = () ->
               y = () ->
                   1234
-            """
+            '''
 
         'are caught': (source) ->
             errors = coffeelint.lint(source)
@@ -59,11 +59,11 @@ vows.describe('indent').addBatch({
             assert.equal(error.lineNumber, 3)
 
     'Compiler generated indentation':
-        topic: () ->
-            """
+        topic:
+            '''
             () ->
                 if 1 then 2 else 3
-            """
+            '''
 
         'is ignored when not using two spaces': (source) ->
             config =
@@ -73,25 +73,29 @@ vows.describe('indent').addBatch({
             assert.isEmpty(errors)
 
     'Indentation inside interpolation':
-        topic: 'a = "#{ 1234 }"'
+        topic:
+            '''
+            a = "#{ 1234 }"
+            '''
 
         'is ignored': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Indentation in multi-line expressions':
-        topic: """
-        x = '1234' + '1234' + '1234' +
-                '1234' + '1234'
-        """
+        topic:
+            '''
+            x = '1234' + '1234' + '1234' +
+                    '1234' + '1234'
+            '''
 
         'is ignored': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Indentation across line breaks':
-        topic: () ->
-            """
+        topic:
+            '''
             days = ["mon", "tues", "wed",
                        "thurs", "fri"
                                 "sat", "sun"]
@@ -102,14 +106,15 @@ vows.describe('indent').addBatch({
             arr = [() ->
                     1234
             ]
-            """
+            '''
 
         'is ignored': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Indentation on seperate line invocation':
-        topic: """
+        topic:
+            '''
             rockinRockin
                     .around ->
                       3
@@ -117,48 +122,52 @@ vows.describe('indent').addBatch({
             rockrockrock.
                     around ->
                       1234
-            """
+            '''
 
         'is ignored. Issue #4': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Consecutive indented chained invocations':
-        topic: """
+        topic:
+            '''
             $('body')
                 .addClass('k')
                 .removeClass 'k'
                 .animate()
                 .hide()
-            """
+            '''
 
         'is permitted': (source) ->
             assert.isEmpty(coffeelint.lint(source))
 
     'Consecutive chained invocations and blank line':
-        topic: """
+        topic:
+            '''
             $('body')
 
                 .addClass('k').hide()
-            """
+            '''
 
         'is permitted': (source) ->
             assert.isEmpty(coffeelint.lint(source))
 
     'Consecutive indented chained invocations and multi-line expression':
-        topic: """
+        topic:
+            '''
             $('body')
               .addClass ->
                 return $(this).name + $(this).that +
                   $(this).this
               .removeClass 'k'
-            """
+            '''
 
         'is permitted': (source) ->
             assert.isEmpty(coffeelint.lint(source))
 
     'Consecutive indented chained invocations with bad indents':
-        topic: """
+        topic:
+            '''
             $('body')
               .addClass('k')
                  # bad indented comments are ignored
@@ -169,7 +178,7 @@ vows.describe('indent').addBatch({
                 # comments are ignored
                  .hide() # this will check with '.animated()' and complain
 
-            """
+            '''
         'fails with indent error': (source) ->
             errors = coffeelint.lint(source)
             assert.equal(errors.length, 1)
@@ -180,10 +189,11 @@ vows.describe('indent').addBatch({
             assert.equal(error.context, 'Expected 2 got 3')
 
     'One chain invocations with bad indents':
-        topic: """
+        topic:
+            '''
             $('body')
                .addClass('k')
-            """
+            '''
         'fails with indent error': (source) ->
             errors = coffeelint.lint(source)
             assert.equal(errors.length, 1)
@@ -194,7 +204,8 @@ vows.describe('indent').addBatch({
             assert.equal(error.context, 'Expected 2 got 3')
 
     'Separate chained invocations with bad indents':
-        topic: """
+        topic:
+            '''
             $('body')
               .addClass ->
                 return name + that +
@@ -203,7 +214,7 @@ vows.describe('indent').addBatch({
 
             $('html')
                .hello()
-            """
+            '''
 
         'correctly identifies two errors': (source) ->
             errors = coffeelint.lint(source)
@@ -222,8 +233,8 @@ vows.describe('indent').addBatch({
 
 
     'Ignore comment in indented chained invocations':
-        topic: () ->
-            """
+        topic:
+            '''
             test()
                 .r((s) ->
                     # Ignore this comment
@@ -234,7 +245,7 @@ vows.describe('indent').addBatch({
                     y()
                 )
                 .s()
-            """
+            '''
         'no error when comment is in first line of a chain': (source) ->
             config =
                 indentation:
@@ -244,7 +255,7 @@ vows.describe('indent').addBatch({
 
     'Ignore blank line in indented chained invocations':
         topic:
-            """
+            '''
             test()
                 .r((s) ->
 
@@ -254,7 +265,7 @@ vows.describe('indent').addBatch({
                     y()
                 )
                 .s()
-            """
+            '''
         'no error when blank line is in first line of a chain': (source) ->
             config =
                 indentation:
@@ -263,29 +274,32 @@ vows.describe('indent').addBatch({
             assert.isEmpty(errors)
 
     'Arbitrarily indented arguments':
-        topic: """
+        topic:
+            '''
             myReallyLongFunction withLots,
                                  ofArguments,
                                  everywhere
-            """
+            '''
 
         'are permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Indenting a callback in a chained call inside a function':
-        topic: """
+        topic:
+            '''
             someFunction = ->
               $.when(somePromise)
                 .done (result) ->
                   foo = result.bar
-            """
+            '''
         'is permitted. See issue #88': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Handle multiple chained calls':
-        topic: """
+        topic:
+            '''
             anObject
               .firstChain (f) ->
                 doStepOne()
@@ -294,13 +308,14 @@ vows.describe('indent').addBatch({
               .secondChain (s) ->
                 moreStuff()
                 return s
-            """
+            '''
         'is permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Handle multiple chained calls (4 spaces)':
-        topic: """
+        topic:
+            '''
             anObject
                 .firstChain (f) ->
                     doStepOne()
@@ -309,7 +324,7 @@ vows.describe('indent').addBatch({
                 .secondChain (s) ->
                     moreStuff()
                     return s
-            """
+            '''
         'fails when using 2 space indentation default': (source) ->
             msg = 'Line contains inconsistent indentation'
 
@@ -337,7 +352,8 @@ vows.describe('indent').addBatch({
             assert.isEmpty(errors)
 
     'Handle multiple chained calls inside more indentation':
-        topic: """
+        topic:
+            '''
             someLongFunction = (a, b, c, d) ->
               retValue = anObject
                 .firstChain (f) ->
@@ -350,13 +366,14 @@ vows.describe('indent').addBatch({
 
               retValue + [1]
 
-            """
+            '''
         'is permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Handle chains where there are tokens with generated property':
-        topic: """
+        topic:
+            '''
             anObject 'bar'
               .firstChain ->
                 doStepOne()
@@ -367,13 +384,14 @@ vows.describe('indent').addBatch({
                   .then ->
                     e ->
                   .finally x
-            """
+            '''
         'is permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Handle nested chain calls':
-        topic: """
+        topic:
+            '''
             anObject
               .firstChain (f) ->
                 doStepOne()
@@ -382,13 +400,14 @@ vows.describe('indent').addBatch({
               .secondChain (s) ->
                 moreStuff()
                 return s
-            """
+            '''
         'is permitted': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
     'Make sure indentation check is not affected outside proper scope':
-        topic: """
+        topic:
+            '''
             a
               .b
 
@@ -400,7 +419,7 @@ vows.describe('indent').addBatch({
                 (false or
                   long.expression.that.necessitates(linebreak))
                 @foo()
-            """
+            '''
         'returns no errors outside scope': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
@@ -424,7 +443,8 @@ vows.describe('indent').addBatch({
     # Fixes people wanted to heavily indent if statements attached to assignment
     # See: #468, #345
     'Handle different if statements indentations':
-        topic: '''
+        topic:
+            '''
             r = unless p1
               if p2
                 1

--- a/test/test_levels.coffee
+++ b/test/test_levels.coffee
@@ -6,8 +6,10 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('levels').addBatch({
 
     'CoffeeLint':
-
-        topic: "abc = 123;",
+        topic:
+            '''
+            abc = 123;
+            '''
 
         'can ignore errors': (source) ->
             config =

--- a/test/test_line_endings.coffee
+++ b/test/test_line_endings.coffee
@@ -7,7 +7,10 @@ vows.describe('line endings').addBatch({
 
     'Unix line endings':
 
-        topic: 'x = 1\ny=2'
+        topic:
+            '''
+            x = 1\ny=2
+            '''
 
         'are allowed by default': (source) ->
             errors = coffeelint.lint(source)
@@ -25,8 +28,11 @@ vows.describe('line endings').addBatch({
             assert.equal(error.rule, 'line_endings')
 
     'Windows line endings':
+        topic:
+            '''
+            x = 1\r\ny=2
+            '''
 
-        topic: 'x = 1\r\ny=2'
         'are allowed by default': (source) ->
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
@@ -43,8 +49,10 @@ vows.describe('line endings').addBatch({
             assert.equal(error.rule, 'line_endings')
 
     'Unknown line endings':
-
-        topic: 'x = 1\ny=2'
+        topic:
+            '''
+            x = 1\ny=2
+            '''
 
         'throw errors': (source) ->
             config =

--- a/test/test_max_line_length.coffee
+++ b/test/test_max_line_length.coffee
@@ -11,14 +11,14 @@ vows.describe('linelength').addBatch({
             line = (length) ->
                 return '# ' + new Array(length - 1).join('-')
             lengths = [50, 79, 80, 81, 100, 200]
-            (line(l) for l in lengths).join("\n")
+            (line(l) for l in lengths).join('\n')
 
         'defaults to 80': (source) ->
             errors = coffeelint.lint(source)
             assert.equal(errors.length, 3)
             error = errors[0]
             assert.equal(error.lineNumber, 4)
-            assert.equal(error.message, "Line exceeds maximum allowed length")
+            assert.equal(error.message, 'Line exceeds maximum allowed length')
             assert.equal(error.rule, 'max_line_length')
 
         'is configurable': (source) ->
@@ -47,7 +47,7 @@ vows.describe('linelength').addBatch({
             assert.isEmpty(errors)
 
         'respects Windows line breaks': ->
-            source = new Array(81).join('X') + "\r\n"
+            source = new Array(81).join('X') + '\r\n'
 
             errors = coffeelint.lint(source, {})
             assert.isEmpty(errors)
@@ -55,24 +55,25 @@ vows.describe('linelength').addBatch({
     'Literate Line Length':
         topic: ->
             # This creates a line with 80 Xs.
-            source = new Array(81).join('X') + "\n"
+            source = new Array(81).join('X') + '\n'
 
             # Long URLs are ignored by default even in Literate code.
-            source += "http://testing.example.com/really-really-long-url-" +
-                "that-shouldnt-have-to-be-split-to-avoid-the-lint-error"
+            source += 'http://testing.example.com/really-really-long-url-' +
+                'that-shouldnt-have-to-be-split-to-avoid-the-lint-error'
 
         '': (source) ->
             errors = coffeelint.lint(source, {}, true)
             assert.isEmpty(errors)
 
     'Maximum length exceptions':
-        topic: """
+        topic:
+            '''
             # Since the line length check only reads lines in isolation it will
             # see the following line as a comment even though it's in a string.
             # I don't think that's a problem.
             #
             # http://testing.example.com/really-really-long-url-that-shouldnt-have-to-be-split-to-avoid-the-lint-error
-        """
+            '''
 
         'excludes long urls': (source) ->
             errors = coffeelint.lint(source)

--- a/test/test_no_backticks.coffee
+++ b/test/test_no_backticks.coffee
@@ -7,7 +7,10 @@ vows.describe('backticks').addBatch({
 
     'Backticks':
 
-        topic: "`with(document) alert(height);`"
+        topic:
+            '''
+            `with(document) alert(height);`
+            '''
 
         'are forbidden by default': (source) ->
             errors = coffeelint.lint(source)
@@ -16,7 +19,7 @@ vows.describe('backticks').addBatch({
             error = errors[0]
             assert.equal(error.rule, 'no_backticks')
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Backticks are forbidden")
+            assert.equal(error.message, 'Backticks are forbidden')
 
         'can be permitted': (source) ->
             config = {no_backticks: {level: 'ignore'}}

--- a/test/test_no_debugger.coffee
+++ b/test/test_no_debugger.coffee
@@ -7,21 +7,22 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('no_debugger').addBatch({
 
     'console calls':
-        topic: '''
-        console.log("hello world")
-        '''
+        topic:
+            '''
+            console.log("hello world")
+            '''
 
         'causes a warning when present': (source) ->
             errors = coffeelint.lint(source, {
                 no_debugger:
-                    'level': 'error'
-                    "console": true
+                    level: 'error'
+                    console: true
             })
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
 
     'The debugger statement':
-        topic: ->
+        topic:
             '''
             debugger
             '''

--- a/test/test_no_empty_param_list.coffee
+++ b/test/test_no_empty_param_list.coffee
@@ -7,7 +7,7 @@ vows.describe('params').addBatch({
 
     'Empty param list':
 
-        topic: () ->
+        topic:
             '''
             blah = () ->
             '''

--- a/test/test_no_implicit_braces.coffee
+++ b/test/test_no_implicit_braces.coffee
@@ -7,7 +7,7 @@ vows.describe('no_implicit_braces').addBatch({
 
     'Implicit braces':
 
-        topic: () ->
+        topic:
             '''
             a = 1: 2
             y =
@@ -31,22 +31,23 @@ vows.describe('no_implicit_braces').addBatch({
             assert.equal(error.rule, 'no_implicit_braces')
 
     'Implicit braces strict':
-        topic: """
+        topic:
+            '''
             foo =
               bar:
                 baz: 1
                 thing: 'a'
               baz: ['a', 'b', 'c']
-        """
+            '''
 
-        "blocks all implicit braces by default": (source) ->
+        'blocks all implicit braces by default': (source) ->
             config = {no_implicit_braces: {level: 'error'}}
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 2)
             assert.equal(rule, 'no_implicit_braces') for {rule} in errors
 
-        "allows braces at the end of lines when strict is false": (source) ->
+        'allows braces at the end of lines when strict is false': (source) ->
             config =
                 no_implicit_braces:
                     level: 'error'
@@ -56,7 +57,7 @@ vows.describe('no_implicit_braces').addBatch({
             assert.isEmpty(errors)
 
     'Implicit braces in class definitions':
-        topic: () ->
+        topic:
             '''
             class Animal
               walk: ->
@@ -88,7 +89,7 @@ vows.describe('no_implicit_braces').addBatch({
             assert.isEmpty(errors)
 
     'Test against use of implicit braces in loop with conditional (#459)':
-        topic: () ->
+        topic:
             '''
 
             list =

--- a/test/test_no_implicit_parens.coffee
+++ b/test/test_no_implicit_parens.coffee
@@ -7,7 +7,7 @@ vows.describe('parens').addBatch({
 
 
     'Implicit parens':
-        topic: () ->
+        topic:
             '''
             console.log 'implict parens'
             blah = (a, b) ->
@@ -41,7 +41,8 @@ vows.describe('parens').addBatch({
             assert.equal(error.rule, 'no_implicit_parens')
 
     'No implicit parens strict':
-        topic: """
+        topic:
+            '''
             blah = (a) ->
             blah
               foo: 'bar'
@@ -49,7 +50,7 @@ vows.describe('parens').addBatch({
             blah = (a, b) ->
             blah 'a'
             , 'b'
-        """
+            '''
 
         'blocks all implicit parens by default': (source) ->
             config = {no_implicit_parens: {level: 'error'}}
@@ -68,7 +69,8 @@ vows.describe('parens').addBatch({
             assert.isEmpty(errors)
 
     'Nested no implicit parens strict':
-        topic: """
+        topic:
+            '''
             blah = (a) ->
             blah
               foo: blah('a')
@@ -81,7 +83,7 @@ vows.describe('parens').addBatch({
             blah 'a'
             , (blah 'c'
             , 'd')
-        """
+            '''
 
         'blocks all implicit parens by default': (source) ->
             config = {no_implicit_parens: {level: 'error'}}
@@ -100,7 +102,8 @@ vows.describe('parens').addBatch({
             assert.isEmpty(errors)
 
     'Test for when implicit parens are on the last line':
-        topic: """
+        topic:
+            '''
             class Something
               constructor: ->
                 return $ '#something'
@@ -113,8 +116,8 @@ vows.describe('parens').addBatch({
 
             blah 'a'
             , blah('c', 'd')
+            '''
 
-        """
         'throws three errors when strict is true': (source) ->
             config =
                 no_implicit_parens:

--- a/test/test_no_interpolation_in_single_quotes.coffee
+++ b/test/test_no_interpolation_in_single_quotes.coffee
@@ -7,7 +7,7 @@ vows.describe('no_interpolation_in_single_quotes').addBatch({
 
     'Interpolation in single quotes':
 
-        topic: () ->
+        topic:
             '''
             foo = '#{inter}foo#{polation}'
             '''
@@ -26,8 +26,7 @@ vows.describe('no_interpolation_in_single_quotes').addBatch({
             assert.equal(error.rule, 'no_interpolation_in_single_quotes')
 
     'Interpolation in double quotes':
-
-        topic: () ->
+        topic:
             '''
             foo = "#{inter}foo#{polation}"
             bar = "ive\#{escaped}"

--- a/test/test_no_nested_string_interpolation.coffee
+++ b/test/test_no_nested_string_interpolation.coffee
@@ -6,10 +6,10 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('no_nested_string_interpolation').addBatch({
 
     'Non-nested string interpolation':
-
-        topic: '''
-        "Book by #{firstName.toUpperCase()} #{lastName.toUpperCase()}"
-        '''
+        topic:
+            '''
+            "Book by #{firstName.toUpperCase()} #{lastName.toUpperCase()}"
+            '''
 
         'is allowed': (source) ->
             errors = coffeelint.lint(source)
@@ -17,10 +17,11 @@ vows.describe('no_nested_string_interpolation').addBatch({
             assert.isEmpty(errors)
 
     'Nested string interpolation':
+        topic:
+            '''
+            str = "Book by #{"#{firstName} #{lastName}".toUpperCase()}"
+            '''
 
-        topic: '''
-        str = "Book by #{"#{firstName} #{lastName}".toUpperCase()}"
-        '''
         'should generate a warning': (source) ->
             errors = coffeelint.lint(source)
             assert.isArray(errors)
@@ -39,11 +40,12 @@ vows.describe('no_nested_string_interpolation').addBatch({
             assert.isEmpty(errors)
 
     'Deeply nested string interpolation':
-        topic: '''
-        str1 = "string #{"interpolation #{"inception"}"}"
-        str2 = "going #{"in #{"even #{"deeper"}"}"}"
-        str3 = "#{"multiple #{"warnings"}"} for #{"different #{"nestings"}"}"
-        '''
+        topic:
+            '''
+            str1 = "string #{"interpolation #{"inception"}"}"
+            str2 = "going #{"in #{"even #{"deeper"}"}"}"
+            str3 = "#{"multiple #{"warnings"}"} for #{"diff #{"nestings"}"}"
+            '''
 
         'generates only one warning per string': (source) ->
             errors = coffeelint.lint(source)

--- a/test/test_no_plusplus.coffee
+++ b/test/test_no_plusplus.coffee
@@ -7,7 +7,8 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('plusplus').addBatch({
 
     'The increment and decrement operators':
-        topic: '''
+        topic:
+            '''
             y++
             ++y
             x--

--- a/test/test_no_private_function_fat_arrows.coffee
+++ b/test/test_no_private_function_fat_arrows.coffee
@@ -12,40 +12,40 @@ vows.describe('no_private_function_fat_arrows').addBatch({
 
     'eol':
         'should warn with fat arrow': ->
-            result = coffeelint.lint("""
+            result = coffeelint.lint('''
             class Foo
               foo = =>
-            """, config)
+            ''', config)
             assert.equal(result.length, 1)
             assert.equal(result[0].rule,  'no_private_function_fat_arrows')
             assert.equal(result[0].level, 'error')
 
         'should work with nested classes': ->
-            result = coffeelint.lint("""
+            result = coffeelint.lint('''
             class Bar
               foo = ->
                 class
                   bar2 = =>
-            """, config)
+            ''', config)
             assert.equal(result.length, 1)
             assert.equal(result[0].rule,  'no_private_function_fat_arrows')
             assert.equal(result[0].level, 'error')
 
             # Same method name as external function.
-            result = coffeelint.lint("""
+            result = coffeelint.lint('''
             class Bar
               foo = ->
                 class
                   foo = =>
-            """, config)
+            ''', config)
             assert.equal(result.length, 1)
             assert.equal(result[0].rule,  'no_private_function_fat_arrows')
             assert.equal(result[0].level, 'error')
 
         'should not warn without fat arrow': ->
-            assert.isEmpty(coffeelint.lint("""
+            assert.isEmpty(coffeelint.lint('''
             class Foo
               foo = ->
-            """, config))
+            ''', config))
 
 }).export(module)

--- a/test/test_no_stand_alone_at.coffee
+++ b/test/test_no_stand_alone_at.coffee
@@ -6,9 +6,8 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('stand alone @').addBatch({
 
     'Stand alone @':
-
-        topic: () ->
-            """
+        topic:
+            '''
             @alright
             @   .error
             @ok()
@@ -18,7 +17,7 @@ vows.describe('stand alone @').addBatch({
             not(@).ok
             @::ok
             @:: #notok
-            """
+            '''
 
         'are allowed by default': (source) ->
             errors = coffeelint.lint(source)

--- a/test/test_no_tabs.coffee
+++ b/test/test_no_tabs.coffee
@@ -12,12 +12,12 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('tabs').addBatch({
 
     'Tabs':
-        topic: () ->
-            """
+        topic:
+            '''
             x = () ->
             \ty = () ->
             \t\treturn 1234
-            """
+            '''
 
         'can be forbidden': (source) ->
             config = {}
@@ -25,7 +25,7 @@ vows.describe('tabs').addBatch({
             assert.equal(errors.length, 4)
             error = errors[1]
             assert.equal(error.lineNumber, 2)
-            assert.equal("Line contains tab indentation", error.message)
+            assert.equal(error.message, 'Line contains tab indentation')
             assert.equal(error.rule, 'no_tabs')
 
         'can be permitted': (source) ->
@@ -48,7 +48,8 @@ vows.describe('tabs').addBatch({
             assert.equal(errors.length, 0)
 
     'Tabs in multi-line strings':
-        topic: '''
+        topic:
+            '''
             x = 1234
             y = """
             \t\tasdf
@@ -60,7 +61,8 @@ vows.describe('tabs').addBatch({
             assert.isEmpty(errors)
 
     'Tabs in Heredocs':
-        topic: '''
+        topic:
+            '''
             ###
             \t\tMy Heredoc
             ###
@@ -71,7 +73,8 @@ vows.describe('tabs').addBatch({
             assert.isEmpty(errors)
 
     'Tabs in multi line regular expressions':
-        topic: '''
+        topic:
+            '''
             ///
             \t\tMy Heredoc
             ///

--- a/test/test_no_throwing_strings.coffee
+++ b/test/test_no_throwing_strings.coffee
@@ -7,13 +7,14 @@ vows.describe('throw').addBatch({
 
     'Throwing strings':
 
-        topic: '''
+        topic:
+            '''
             throw 'my error'
             throw "#{1234}"
             throw """
                 long string
             """
-        '''
+            '''
 
         'is forbidden by default': (source) ->
             errors = coffeelint.lint(source)

--- a/test/test_no_trailing_semicolons.coffee
+++ b/test/test_no_trailing_semicolons.coffee
@@ -10,18 +10,18 @@ vows.describe('semicolons').addBatch({
 
     'Semicolons at end of lines':
 
-        topic: () ->
-            """
+        topic:
+            '''
             x = 1234;
             y = 1234; z = 1234
-            """
+            '''
 
         'are forbidden': (source) ->
             errors = coffeelint.lint(source)
             assert.lengthOf(errors, 1)
             error = errors[0]
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.message, 'Line contains a trailing semicolon')
             assert.equal(error.rule, 'no_trailing_semicolons')
 
         'can be ignored': (source) ->
@@ -29,7 +29,8 @@ vows.describe('semicolons').addBatch({
             assert.isEmpty(errors)
 
     'Semicolons in multiline expressions':
-        topic: '''
+        topic:
+            '''
             x = "asdf;
             asdf"
 
@@ -55,15 +56,20 @@ vows.describe('semicolons').addBatch({
             assert.isEmpty(errors)
 
     'Trailing semicolon in comments':
-        topic: "undefined\n# comment;\nundefined"
+        topic:
+            '''
+            undefined\n# comment;\nundefined
+            '''
 
         'are ignored': (source) ->
             errors = coffeelint.lint(source, {})
             assert.isEmpty(errors)
 
     'Trailing semicolon in comments with no semicolon in statement':
-
-        topic: "x = 3 #set x to 3;"
+        topic:
+            '''
+            x = 3 #set x to 3;
+            '''
 
         'are ignored': (source) ->
             errors = coffeelint.lint(source, configIgnore)
@@ -74,8 +80,10 @@ vows.describe('semicolons').addBatch({
             assert.isEmpty(errors)
 
     'Trailing semicolon in comments with semicolon in statement':
-
-        topic: "x = 3; #set x to 3;"
+        topic:
+            '''
+            x = 3; #set x to 3;
+            '''
 
         'are ignored': (source) ->
             errors = coffeelint.lint(source, configIgnore)
@@ -86,12 +94,14 @@ vows.describe('semicolons').addBatch({
             assert.lengthOf(errors, 1)
             error = errors[0]
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.message, 'Line contains a trailing semicolon')
             assert.equal(error.rule, 'no_trailing_semicolons')
 
     'Trailing semicolon in block comments':
-
-        topic: "###\nThis is a block comment;\n###"
+        topic:
+            '''
+            ###\nThis is a block comment;\n###
+            '''
 
         'are ignored': (source) ->
             errors = coffeelint.lint(source, configIgnore)
@@ -102,9 +112,10 @@ vows.describe('semicolons').addBatch({
             assert.isEmpty(errors)
 
     'Semicolons with windows line endings':
-
-        topic: () ->
-            "x = 1234;\r\n"
+        topic:
+            '''
+            x = 1234;\r\n
+            '''
 
         'works as expected': (source) ->
             config = { line_endings: { value: 'windows' } }
@@ -112,11 +123,11 @@ vows.describe('semicolons').addBatch({
             assert.lengthOf(errors, 1)
             error = errors[0]
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.message, 'Line contains a trailing semicolon')
             assert.equal(error.rule, 'no_trailing_semicolons')
 
     'Semicolons inside of blockquote string':
-        topic: () ->
+        topic:
             '''
             foo = bar();
 
@@ -140,7 +151,7 @@ vows.describe('semicolons').addBatch({
             assert.lengthOf(errors, 1)
             error = errors[0]
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line contains a trailing semicolon")
+            assert.equal(error.message, 'Line contains a trailing semicolon')
             assert.equal(error.rule, 'no_trailing_semicolons')
 
 }).export(module)

--- a/test/test_no_trailing_whitespace.coffee
+++ b/test/test_no_trailing_whitespace.coffee
@@ -7,8 +7,10 @@ vows.describe('trailing').addBatch({
 
     'Trailing whitespace':
 
-        topic: () ->
-            "x = 1234      \ny = 1"
+        topic:
+            '''
+            x = 1234      \ny = 1
+            '''
 
         'is forbidden by default': (source) ->
             errors = coffeelint.lint(source)
@@ -16,7 +18,7 @@ vows.describe('trailing').addBatch({
             error = errors[0]
             assert.isObject(error)
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line ends with trailing whitespace")
+            assert.equal(error.message, 'Line ends with trailing whitespace')
             assert.equal(error.rule, 'no_trailing_whitespace')
 
         'can be permitted': (source) ->
@@ -25,7 +27,10 @@ vows.describe('trailing').addBatch({
             assert.equal(errors.length, 0)
 
     'Trailing whitespace in comments':
-        topic: "x = 1234  # markdown comment    \ny=1"
+        topic:
+            '''
+            x = 1234  # markdown comment    \ny=1
+            '''
 
         'is forbidden by default': (source) ->
             errors = coffeelint.lint(source)
@@ -33,7 +38,7 @@ vows.describe('trailing').addBatch({
             error = errors[0]
             assert.isObject(error)
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Line ends with trailing whitespace")
+            assert.equal(error.message, 'Line ends with trailing whitespace')
             assert.equal(error.rule, 'no_trailing_whitespace')
 
         'can be permitted': (source) ->
@@ -41,15 +46,18 @@ vows.describe('trailing').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
-    "a # in a string":
+    'a # in a string':
         topic: "x = 'some # string'   "
-        "does not confuse trailing_whitespace": (source) ->
+        'does not confuse trailing_whitespace': (source) ->
             config = {no_trailing_whitespace: {allowed_in_comments: true}}
             errors = coffeelint.lint(source, config)
             assert.isNotEmpty(errors)
 
-    "Trailing whitespace in block comments":
-        topic: "###\nblock comment with trailing space:   \n###"
+    'Trailing whitespace in block comments':
+        topic:
+            '''
+            ###\nblock comment with trailing space:   \n###
+            '''
 
         'is forbidden by default': (source) ->
             errors = coffeelint.lint(source)
@@ -57,7 +65,7 @@ vows.describe('trailing').addBatch({
             error = errors[0]
             assert.isObject(error)
             assert.equal(error.lineNumber, 2)
-            assert.equal(error.message, "Line ends with trailing whitespace")
+            assert.equal(error.message, 'Line ends with trailing whitespace')
             assert.equal(error.rule, 'no_trailing_whitespace')
 
         'can be permitted': (source) ->
@@ -65,8 +73,11 @@ vows.describe('trailing').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
-    "On empty lines": # https://github.com/clutchski/coffeelint/issues/39
-        topic: "x = 1234\n     \n"
+    'On empty lines': # https://github.com/clutchski/coffeelint/issues/39
+        topic:
+            '''
+            x = 1234\n     \n
+            '''
 
         'allowed by default': (source) ->
             errors = coffeelint.lint(source)
@@ -80,20 +91,24 @@ vows.describe('trailing').addBatch({
             error = errors[0]
             assert.isObject(error)
             assert.equal(error.lineNumber, 2)
-            assert.equal(error.message, "Line ends with trailing whitespace")
+            assert.equal(error.message, 'Line ends with trailing whitespace')
             assert.equal(error.rule, 'no_trailing_whitespace')
 
     'Trailing tabs':
-
-        topic: () ->
-            "x = 1234\t"
+        topic:
+            '''
+            x = 1234\t
+            '''
 
         'are forbidden as well': (source) ->
             errors = coffeelint.lint(source, {})
             assert.equal(errors.length, 1)
 
     'Windows line endings':
-        topic: 'x = 1234\r\ny = 5678'
+        topic:
+            '''
+            x = 1234\r\ny = 5678
+            '''
 
         'are permitted': (source) ->
             assert.isEmpty(coffeelint.lint(source))

--- a/test/test_no_unnecessary_double_quotes.coffee
+++ b/test/test_no_unnecessary_double_quotes.coffee
@@ -6,7 +6,7 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('no_unnecessary_double_quotes').addBatch({
 
     'Single quotes':
-        topic: () ->
+        topic:
             '''
             foo = 'single'
             '''
@@ -19,7 +19,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Unnecessary double quotes':
-        topic: () ->
+        topic:
             '''
             foo = "double"
             '''
@@ -43,8 +43,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Useful double quotes':
-
-        topic: () ->
+        topic:
             '''
             interpolation = "inter#{polation}"
             multipleInterpolation = "#{foo}bar#{baz}"
@@ -59,8 +58,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Block strings with double quotes':
-
-        topic: () ->
+        topic:
             '''
             foo = """
               doubleblock
@@ -80,8 +78,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Block strings with useful double quotes':
-
-        topic: () ->
+        topic:
             '''
             foo = """
               #{interpolation}foo 'some single quotes for good measure'
@@ -96,8 +93,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Block strings with single quotes':
-
-        topic: () ->
+        topic:
             """
             foo = '''
               singleblock
@@ -112,7 +108,7 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
 
     'Hand concatenated string with parenthesis':
-        topic: () ->
+        topic:
             '''
             foo = (("inter") + "polation")
             '''
@@ -130,10 +126,10 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
 
     'use strict':
         topic:
-            """
+            '''
             "use strict"
             foo = 'foo'
-            """
+            '''
 
         'should not error at the start of the file #306': (source) ->
             config = {no_unnecessary_double_quotes: {level: 'error'}}
@@ -145,7 +141,10 @@ vows.describe('no_unnecessary_double_quotes').addBatch({
             assert.equal(error.rule, 'no_unnecessary_double_quotes')
 
     'Test RegExp flags #405':
-        topic: 'd = ///#{foo}///i'
+        topic:
+            '''
+            d = ///#{foo}///i
+            '''
 
         'should not generate an error': (source) ->
             config = {no_unnecessary_double_quotes: {level: 'error'}}

--- a/test/test_no_unnecessary_fat_arrows.coffee
+++ b/test/test_no_unnecessary_fat_arrows.coffee
@@ -49,11 +49,11 @@ vows.describe('no unnecessary fat arrows').addBatch({
     'deeply nested simple function': shouldError '-> -> -> -> => 1'
     'deeply nested function with this': shouldPass '-> -> -> -> => this'
 
-    'functions with multiple statements': shouldError """
+    'functions with multiple statements': shouldError '''
         f = ->
           x = 2
           z ((a) => x; a)
-        """
+        '''
 
     'functions with parameters': shouldError '(a) =>'
     'functions with parameter assignment': shouldPass '(@a) =>'

--- a/test/test_non_empty_constructor_needs_parens.coffee
+++ b/test/test_non_empty_constructor_needs_parens.coffee
@@ -7,8 +7,8 @@ vows.describe('non_empty_constructor_needs_parens').addBatch({
 
 
     'Missing Parentheses on "new Foo 1, 2"':
-        topic: () ->
-            """
+        topic:
+            '''
             class Foo
 
             a = new Foo
@@ -29,7 +29,7 @@ vows.describe('non_empty_constructor_needs_parens').addBatch({
             j = new bar.foo.Foo(
               config: 'parameter'
             )
-            """
+            '''
 
         'warns about missing parens': (source) ->
             config =

--- a/test/test_prefer_english_operator.coffee
+++ b/test/test_prefer_english_operator.coffee
@@ -58,18 +58,20 @@ vows.describe('PreferEnglishOperatorssemicolons').addBatch({
             assert.isEmpty(coffeelint.lint('1 or 1', configError))
 
     'Comments': ->
-        topic: """
-        # 1 == 1
-        # 1 != 1
-        # 1 && 1
-        # 1 || 1
-        ###
-        1 == 1
-        1 != 1
-        1 && 1
-        1 || 1
-        ###
-        """
+        topic:
+            '''
+            # 1 == 1
+            # 1 != 1
+            # 1 && 1
+            # 1 || 1
+            ###
+            1 == 1
+            1 != 1
+            1 && 1
+            1 || 1
+            ###
+            '''
+
         'should not warn when == is used in a comment': (source) ->
             assert.isEmpty(coffeelint.lint(source, configError))
 
@@ -85,7 +87,7 @@ vows.describe('PreferEnglishOperatorssemicolons').addBatch({
                 """
                 1 == 1
                 """
-            '''
+                '''
             assert.isEmpty(coffeelint.lint(source, configError))
 
 }).export(module)

--- a/test/test_reporters.coffee
+++ b/test/test_reporters.coffee
@@ -17,11 +17,11 @@ class PassThroughReporter extends RawReporter
 vows.describe('reporters').addBatch({
 
     'Can be used by 3rd party projects':
-
-        topic: """
+        topic:
+            '''
             if true
                 undefined
-            """
+            '''
 
         '(example)': (code) ->
 

--- a/test/test_space_operators.coffee
+++ b/test/test_space_operators.coffee
@@ -7,7 +7,7 @@ vows.describe('spacing').addBatch({
 
     'No spaces around binary operators':
 
-        topic: ->
+        topic:
             '''
             x= 1
             1+ 1
@@ -100,15 +100,14 @@ vows.describe('spacing').addBatch({
                 no_nested_string_interpolation: {level: 'ignore'}
             }
             errors = coffeelint.lint(source, config)
-            assert.lengthOf(errors, source.split("\n").length)
+            assert.lengthOf(errors, source.split('\n').length)
             error = errors[0]
             assert.equal(error.rule, 'space_operators')
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Operators must be spaced properly")
+            assert.equal(error.message, 'Operators must be spaced properly')
 
     'Correctly spaced operators':
-
-        topic: ->
+        topic:
             '''
             x = 1
             1 + 1
@@ -178,8 +177,7 @@ vows.describe('spacing').addBatch({
             assert.isEmpty(errors)
 
     'Spaces around unary operators':
-
-        topic: ->
+        topic:
             '''
             + 1
             - - 1

--- a/test/test_spacing_after_comma.coffee
+++ b/test/test_spacing_after_comma.coffee
@@ -6,9 +6,10 @@ coffeelint = require path.join('..', 'lib', 'coffeelint')
 vows.describe('commas').addBatch({
 
     'regex':
-        topic: '''
-        ///^#{ inputValue }///i.test field.name
-        '''
+        topic:
+            '''
+            ///^#{ inputValue }///i.test field.name
+            '''
 
         'should not error': (source) ->
             config = {spacing_after_comma: {level: 'warn'}}
@@ -17,9 +18,10 @@ vows.describe('commas').addBatch({
 
 
     'Whitespace after commas':
-
-        topic: () ->
-            "doSomething(foo = ',',bar)\nfooBar()"
+        topic:
+            '''
+            doSomething(foo = ',',bar)\nfooBar()
+            '''
 
         'permitted by default': (source) ->
             errors = coffeelint.lint(source)
@@ -32,12 +34,11 @@ vows.describe('commas').addBatch({
             error = errors[0]
             assert.isObject(error)
             assert.equal(error.lineNumber, 1)
-            assert.equal(error.message, "Spaces are required after commas")
+            assert.equal(error.message, 'a space is required after commas')
             assert.equal(error.rule, 'spacing_after_comma')
 
     'newline after commas':
-
-        topic: () ->
+        topic:
             '''
             multiLineFuncCall(
               arg1,

--- a/test/test_transform_messes_up_line_numbers.coffee
+++ b/test/test_transform_messes_up_line_numbers.coffee
@@ -11,7 +11,10 @@ cloud = path.join(thisdir, 'fixtures', 'cloud_transform.coffee')
 
 vows.describe('transform_messes_up_line_numbers').addBatch({
     'transform_messes_up_line_numbers':
-        'topic': '''console.log('Hello cloud')'''
+        topic:
+            '''
+            console.log('Hello cloud')
+            '''
 
         'will warn if the number of lines changes': (source) ->
             config =


### PR DESCRIPTION
This enables the `no_unnecessary_double_quotes` rule to be used for
development of coffeelint

```coffeescript
"no_unnecessary_double_quotes": {
    "level": "error"
}
```