### PR TITLE
spacing_after_comma: enable this for development

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -26,6 +26,9 @@
         "level": "error",
         "console": true
     },
+    "spacing_after_comma": {
+        "level": "error"
+    },
     "no_unnecessary_double_quotes": {
         "level": "error"
     }

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -300,8 +300,8 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
         s = LineLinter.configStatement.exec(l)
         if s?.length > 2 and 'enable' in s
             for r in s[1..]
-                unless r in ['enable','disable']
-                    unless r of config and config[r].level in ['warn','error']
+                unless r in ['enable', 'disable']
+                    unless r of config and config[r].level in ['warn', 'error']
                         disabled_initially.push r
                         config[r] = { level: 'error' }
 

--- a/src/rules/spacing_after_comma.coffee
+++ b/src/rules/spacing_after_comma.coffee
@@ -25,7 +25,7 @@ module.exports = class SpacingAfterComma
 
         unless token.spaced or token.newLine or token.generated or
                 @isRegexFlag(token, tokenApi)
-            {context: token[1]}
+            return true
 
     # When generating a regex (///${whatever}///i) CoffeeScript generates tokens
     # for RegEx(whatever, "i") but doesn't bother to mark that comma as

--- a/test/test_spacing_after_comma.coffee
+++ b/test/test_spacing_after_comma.coffee
@@ -32,7 +32,6 @@ vows.describe('commas').addBatch({
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 1)
             error = errors[0]
-            assert.isObject(error)
             assert.equal(error.lineNumber, 1)
             assert.equal(error.message, 'a space is required after commas')
             assert.equal(error.rule, 'spacing_after_comma')


### PR DESCRIPTION
Adding the rule, `spacing_after_comma` for coffeelint development.

Also removed unnecessary check for isObject in test