### PR TITLE
npmignore coffeelint.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 test/
 .git*
 utils/
+coffeelint.json


### PR DESCRIPTION
I've seen a few people think they can just go modifying this file to change the global/default configuration. I think it's best to just not package it on npm.