### PR TITLE
braces_spacing: enable rule for coffeelint development

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -31,5 +31,9 @@
     },
     "no_unnecessary_double_quotes": {
         "level": "error"
+    },
+    "braces_spacing": {
+        "level": "error",
+        "spaces": 1
     }
 }

--- a/src/error_report.coffee
+++ b/src/error_report.coffee
@@ -19,7 +19,7 @@ module.exports = class ErrorReport
             for error in errors
                 errorCount++ if error.level is 'error'
                 warningCount++ if error.level is 'warn'
-        return {errorCount, warningCount, pathCount}
+        return { errorCount, warningCount, pathCount }
 
     getErrors: (path) ->
         return @paths[path]

--- a/src/rules/camel_case_classes.coffee
+++ b/src/rules/camel_case_classes.coffee
@@ -49,4 +49,4 @@ module.exports = class CamelCaseClasses
 
         # Now check for the error.
         if not regexes.camelCase.test(className)
-            return {context: "class name: #{className}"}
+            return { context: "class name: #{className}" }

--- a/src/rules/line_endings.coffee
+++ b/src/rules/line_endings.coffee
@@ -23,6 +23,6 @@ module.exports = class LineEndings
         else
             throw new Error("unknown line ending type: #{ending}")
         if not valid
-            return {context: "Expected #{ending}"}
+            return { context: "Expected #{ending}" }
         else
             return null

--- a/src/rules/no_debugger.coffee
+++ b/src/rules/no_debugger.coffee
@@ -15,9 +15,9 @@ module.exports = class NoDebugger
 
     lintToken: (token, tokenApi) ->
         if token[0] is 'DEBUGGER'
-            return {context: "found '#{token[0]}'"}
+            return { context: "found '#{token[0]}'" }
 
         if tokenApi.config[@rule.name]?.console
             if token[1] is 'console' and tokenApi.peek(1)?[0] is '.'
                 method = tokenApi.peek(2)
-                return {context: "found 'console.#{method[1]}'"}
+                return { context: "found 'console.#{method[1]}'" }

--- a/src/rules/no_plusplus.coffee
+++ b/src/rules/no_plusplus.coffee
@@ -16,4 +16,4 @@ module.exports = class NoPlusPlus
     tokens: [ '++', '--' ]
 
     lintToken: (token, tokenApi) ->
-        return {context: "found '#{token[0]}'"}
+        return { context: "found '#{token[0]}'" }

--- a/src/rules/space_operators.coffee
+++ b/src/rules/space_operators.coffee
@@ -48,14 +48,14 @@ module.exports = class SpaceOperators
         if (isUnary and token.spaced?) or
                 (not isUnary and not token.newLine and
                 (not token.spaced or (p and not p.spaced)))
-            return {context: token[1]}
+            return { context: token[1] }
         else
             null
 
     lintMath: (token, tokenApi) ->
         p = tokenApi.peek(-1)
         if not token.newLine and (not token.spaced or (p and not p.spaced))
-            return {context: token[1]}
+            return { context: token[1] }
         else
             null
 

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -124,7 +124,7 @@ vows.describe(RULE).addBatch({
             assert.equal(errors[4].lineNumber, 14)
             assert.equal(errors[5].lineNumber, 16)
             assert.equal(errors[6].lineNumber, 16)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
             assert.lengthOf(errors, 7)
 
         'when spacing is not required around arrow operator': (source) ->

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -53,9 +53,9 @@ configs =
     oneSpace:
         braces_spacing: { level: 'error', spaces: 1 }
     zeroEmptyObjectSpaces:
-        braces_spacing: {level: 'error', empty_object_spaces: 0}
+        braces_spacing: { level: 'error', empty_object_spaces: 0 }
     zeroSpaces:
-        braces_spacing: {level: 'error', spaces: 0}
+        braces_spacing: { level: 'error', spaces: 0 }
 
 shouldPass = (source, config = {}) ->
     topic: coffeelint.lint(source, config)

--- a/test/test_camel_case_classes.coffee
+++ b/test/test_camel_case_classes.coffee
@@ -55,8 +55,7 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be permitted': (source) ->
-            config =
-                camel_case_classes: {level: 'ignore'}
+            config = camel_case_classes: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 

--- a/test/test_colon_assignment_spacing.coffee
+++ b/test/test_colon_assignment_spacing.coffee
@@ -85,7 +85,7 @@ vows.describe(RULE).addBatch({
                         left: 1
                         right: 1
             errors = coffeelint.lint(source, config)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
             assert.lengthOf(errors, 3)
 
         'will ignore an error': (source) ->

--- a/test/test_commandline.coffee
+++ b/test/test_commandline.coffee
@@ -6,15 +6,14 @@ path = require 'path'
 fs = require 'fs'
 vows = require 'vows'
 assert = require 'assert'
-{spawn, exec} = require 'child_process'
+{ spawn, exec } = require 'child_process'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 
 # The path to the command line tool.
 coffeelintPath = path.join('..', 'bin', 'coffeelint')
 
-execOptions =
-    cwd: __dirname
+execOptions = cwd: __dirname
 # Run the coffeelint command line with the given
 # args. Callback will be called with (error, stdout,
 # stderr)

--- a/test/test_cyclomatic_complexity.coffee
+++ b/test/test_cyclomatic_complexity.coffee
@@ -7,7 +7,7 @@ RULE = 'cyclomatic_complexity'
 
 # Return the cyclomatic complexity of a code snippet with one function.
 getComplexity = (source) ->
-    config = {cyclomatic_complexity: {level: 'error', value: 0}}
+    config = cyclomatic_complexity: { level: 'error', value: 0 }
     errors = coffeelint.lint(source, config)
     assert.isNotEmpty(errors)
     assert.lengthOf(errors, 1)
@@ -33,7 +33,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be enabled': (source) ->
-            config = {cyclomatic_complexity: {level: 'error'}}
+            config = cyclomatic_complexity: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -271,7 +271,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'works': (source) ->
-            config = {cyclomatic_complexity: {level: 'error'}}
+            config = cyclomatic_complexity: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)

--- a/test/test_eol_last.coffee
+++ b/test/test_eol_last.coffee
@@ -3,7 +3,7 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-configError = {eol_last: {level: 'error'}}
+configError = eol_last: { level: 'error' }
 
 RULE = 'eol_last'
 

--- a/test/test_levels.coffee
+++ b/test/test_levels.coffee
@@ -12,14 +12,12 @@ vows.describe('levels').addBatch({
             '''
 
         'can ignore errors': (source) ->
-            config =
-                no_trailing_semicolons: {level: 'ignore'}
+            config = no_trailing_semicolons: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
         'can return warnings': (source) ->
-            config =
-                no_trailing_semicolons: {level: 'warn'}
+            config = no_trailing_semicolons: { level: 'warn' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -27,8 +25,7 @@ vows.describe('levels').addBatch({
             assert.equal(error.level, 'warn')
 
         'can return errors': (source) ->
-            config =
-                no_trailing_semicolons: {level: 'error'}
+            config = no_trailing_semicolons: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -36,9 +33,7 @@ vows.describe('levels').addBatch({
             assert.equal(error.level, 'error')
 
         'catches unknown levels': (source) ->
-
-            config =
-                no_trailing_semicolons: {level: 'foobar'}
+            config = no_trailing_semicolons: { level: 'foobar' }
             assert.throws () ->
                 coffeelint.lint(source, config)
 

--- a/test/test_line_endings.coffee
+++ b/test/test_line_endings.coffee
@@ -19,7 +19,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {line_endings: {level: 'error', value: 'windows'}}
+            config = line_endings: { level: 'error', value: 'windows' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -40,7 +40,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {line_endings: {level: 'error', value: 'unix'}}
+            config = line_endings: { level: 'error', value: 'unix' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -57,8 +57,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'throw errors': (source) ->
-            config =
-                line_endings: {level: 'error', value: 'osx'}
+            config = line_endings: { level: 'error', value: 'osx' }
             assert.throws () ->
                 coffeelint.lint(source, config)
 

--- a/test/test_no_backticks.coffee
+++ b/test/test_no_backticks.coffee
@@ -23,7 +23,7 @@ vows.describe(RULE).addBatch({
             assert.equal(error.message, 'Backticks are forbidden')
 
         'can be permitted': (source) ->
-            config = {no_backticks: {level: 'ignore'}}
+            config = no_backticks: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)

--- a/test/test_no_debugger.coffee
+++ b/test/test_no_debugger.coffee
@@ -14,11 +14,8 @@ vows.describe(RULE).addBatch({
             '''
 
         'causes a warning when present': (source) ->
-            errors = coffeelint.lint(source, {
-                no_debugger:
-                    level: 'error'
-                    console: true
-            })
+            config = no_debugger: { level: 'error', console: true }
+            errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
 
@@ -38,7 +35,8 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be set to error': (source) ->
-            errors = coffeelint.lint(source, {no_debugger: {'level': 'error'}})
+            config = no_debugger: level: 'error'
+            errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)

--- a/test/test_no_empty_param_list.coffee
+++ b/test/test_no_empty_param_list.coffee
@@ -19,7 +19,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {no_empty_param_list: {level: 'error'}}
+            config = no_empty_param_list: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)

--- a/test/test_no_implicit_braces.coffee
+++ b/test/test_no_implicit_braces.coffee
@@ -22,7 +22,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {no_implicit_braces: {level: 'error'}}
+            config = no_implicit_braces: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 2)
@@ -42,17 +42,18 @@ vows.describe(RULE).addBatch({
             '''
 
         'blocks all implicit braces by default': (source) ->
-            config = {no_implicit_braces: {level: 'error'}}
+            config = no_implicit_braces: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 2)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
         'allows braces at the end of lines when strict is false': (source) ->
             config =
                 no_implicit_braces:
                     level: 'error'
                     strict: false
+
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -84,7 +85,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'are always ignored': (source) ->
-            config = {no_implicit_braces: {level: 'error'}}
+            config = no_implicit_braces: { level: 'error' }
             errors = coffeelint.lint(source)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -109,6 +110,7 @@ vows.describe(RULE).addBatch({
                 no_implicit_braces:
                     level: 'error'
                     strict: false
+
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 0)
@@ -177,6 +179,7 @@ vows.describe(RULE).addBatch({
                 no_implicit_braces:
                     level: 'error'
                     strict: false
+
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 0)
@@ -186,6 +189,7 @@ vows.describe(RULE).addBatch({
                 no_implicit_braces:
                     level: 'error'
                     strict: true
+
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 3)

--- a/test/test_no_implicit_parens.coffee
+++ b/test/test_no_implicit_parens.coffee
@@ -32,7 +32,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {no_implicit_parens: {level: 'error'}}
+            config = no_implicit_parens: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 2)
@@ -54,11 +54,11 @@ vows.describe(RULE).addBatch({
             '''
 
         'blocks all implicit parens by default': (source) ->
-            config = {no_implicit_parens: {level: 'error'}}
+            config = no_implicit_parens: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 2)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
         'allows parens at the end of lines when strict is false': (source) ->
             config =
@@ -87,11 +87,11 @@ vows.describe(RULE).addBatch({
             '''
 
         'blocks all implicit parens by default': (source) ->
-            config = {no_implicit_parens: {level: 'error'}}
+            config = no_implicit_parens: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 4)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
         'allows parens at the end of lines when strict is false': (source) ->
             config =

--- a/test/test_no_interpolation_in_single_quotes.coffee
+++ b/test/test_no_interpolation_in_single_quotes.coffee
@@ -19,7 +19,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'interpolation in single quotes can be forbidden': (source) ->
-            config = {no_interpolation_in_single_quotes: {level: 'error'}}
+            config = no_interpolation_in_single_quotes: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 1)
             error = errors[0]
@@ -34,7 +34,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'interpolation in double quotes is always allowed': (source) ->
-            config = {no_interpolation_in_single_quotes: {level: 'error'}}
+            config = no_interpolation_in_single_quotes: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)

--- a/test/test_no_nested_string_interpolation.coffee
+++ b/test/test_no_nested_string_interpolation.coffee
@@ -36,7 +36,7 @@ vows.describe(RULE).addBatch({
                 'Nested string interpolation is forbidden')
 
         'can be permitted': (source) ->
-            config = {no_nested_string_interpolation: {level: 'ignore'}}
+            config = no_nested_string_interpolation: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -53,7 +53,7 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source)
             assert.isArray(errors)
             assert.lengthOf(errors, 4)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
             assert.equal(errors[0].lineNumber, 1)
             assert.equal(errors[1].lineNumber, 2)
             assert.equal(errors[2].lineNumber, 3)

--- a/test/test_no_plusplus.coffee
+++ b/test/test_no_plusplus.coffee
@@ -22,7 +22,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            errors = coffeelint.lint(source, {no_plusplus: {'level': 'error'}})
+            errors = coffeelint.lint(source, { no_plusplus: 'level': 'error' })
             assert.isArray(errors)
             assert.lengthOf(errors, 4)
             error = errors[0]

--- a/test/test_no_private_function_fat_arrows.coffee
+++ b/test/test_no_private_function_fat_arrows.coffee
@@ -3,10 +3,9 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-config = {
-    no_unnecessary_fat_arrows: {level: 'ignore'}
-    no_private_function_fat_arrows: {level: 'error'}
-}
+config =
+    no_unnecessary_fat_arrows: { level: 'ignore' }
+    no_private_function_fat_arrows: { level: 'error' }
 
 RULE = 'no_private_function_fat_arrows'
 

--- a/test/test_no_stand_alone_at.coffee
+++ b/test/test_no_stand_alone_at.coffee
@@ -27,7 +27,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {no_stand_alone_at: {level: 'error'}}
+            config = no_stand_alone_at: { level: 'error' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 4)

--- a/test/test_no_tabs.coffee
+++ b/test/test_no_tabs.coffee
@@ -21,8 +21,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'can be forbidden': (source) ->
-            config = {}
-            errors = coffeelint.lint(source, config)
+            errors = coffeelint.lint(source)
             assert.equal(errors.length, 4)
             error = errors[1]
             assert.equal(error.lineNumber, 2)
@@ -31,18 +30,18 @@ vows.describe(RULE).addBatch({
 
         'can be permitted': (source) ->
             config =
-                no_tabs: {level: 'ignore'}
-                indentation: {level: 'error', value: 1}
+                no_tabs: { level: 'ignore' }
+                indentation: { level: 'error', value: 1 }
+
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'are forbidden by default': (source) ->
-            config =
-                indentation: {level: 'error', value: 1}
+            config = indentation: { level: 'error', value: 1 }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.equal(errors.length, 2)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
         'are allowed in strings': () ->
             source = "x = () -> '\t'"

--- a/test/test_no_this.coffee
+++ b/test/test_no_this.coffee
@@ -3,7 +3,7 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-configError = {no_this: {level: 'error'}}
+configError = { no_this: { level: 'error' } }
 
 RULE = 'no_this'
 

--- a/test/test_no_throwing_strings.coffee
+++ b/test/test_no_throwing_strings.coffee
@@ -25,7 +25,7 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be permitted': (source) ->
-            config = {no_throwing_strings: {level: 'ignore'}}
+            config = no_throwing_strings: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 

--- a/test/test_no_trailing_semicolons.coffee
+++ b/test/test_no_trailing_semicolons.coffee
@@ -3,8 +3,8 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-configError = {no_trailing_semicolons: {level: 'error'}}
-configIgnore = {no_trailing_semicolons: {level: 'ignore'}}
+configError = no_trailing_semicolons: { level: 'error' }
+configIgnore = no_trailing_semicolons: { level: 'ignore' }
 
 RULE = 'no_trailing_semicolons'
 
@@ -119,7 +119,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'works as expected': (source) ->
-            config = { line_endings: { value: 'windows' } }
+            config = line_endings: { value: 'windows' }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 1)
             error = errors[0]

--- a/test/test_no_trailing_whitespace.coffee
+++ b/test/test_no_trailing_whitespace.coffee
@@ -23,7 +23,7 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be permitted': (source) ->
-            config = {no_trailing_whitespace: {level: 'ignore'}}
+            config = no_trailing_whitespace: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
@@ -43,14 +43,14 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be permitted': (source) ->
-            config = {no_trailing_whitespace: {allowed_in_comments: true}}
+            config = no_trailing_whitespace: { allowed_in_comments: true }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
     'a # in a string':
         topic: "x = 'some # string'   "
         'does not confuse trailing_whitespace': (source) ->
-            config = {no_trailing_whitespace: {allowed_in_comments: true}}
+            config = no_trailing_whitespace: { allowed_in_comments: true }
             errors = coffeelint.lint(source, config)
             assert.isNotEmpty(errors)
 
@@ -70,7 +70,7 @@ vows.describe(RULE).addBatch({
             assert.equal(error.rule, RULE)
 
         'can be permitted': (source) ->
-            config = {no_trailing_whitespace: {allowed_in_comments: true}}
+            config = no_trailing_whitespace: { allowed_in_comments: true }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
@@ -85,7 +85,9 @@ vows.describe(RULE).addBatch({
             assert.equal(errors.length, 0)
 
         'can be forbidden': (source) ->
-            config = {no_trailing_whitespace: {allowed_in_empty_lines: false}}
+            config =
+                no_trailing_whitespace:
+                    allowed_in_empty_lines: false
 
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 1)
@@ -102,7 +104,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'are forbidden as well': (source) ->
-            errors = coffeelint.lint(source, {})
+            errors = coffeelint.lint(source)
             assert.equal(errors.length, 1)
 
     'Windows line endings':

--- a/test/test_no_unnecessary_double_quotes.coffee
+++ b/test/test_no_unnecessary_double_quotes.coffee
@@ -14,7 +14,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'single quotes should always be allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -32,7 +32,7 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'double quotes can be forbidden': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.lengthOf(errors, 1)
@@ -53,7 +53,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'string interpolation should always be allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -68,7 +68,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'block strings with double quotes are not allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 1)
             error = errors[0]
@@ -88,7 +88,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'block strings with useful content should be allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -103,7 +103,7 @@ vows.describe(RULE).addBatch({
             """
 
         'block strings with single quotes should be allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
             assert.isEmpty(errors)
@@ -116,7 +116,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'double quotes should not be allowed': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 2)
             error = errors[0]
@@ -134,7 +134,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'should not error at the start of the file #306': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             # Without the fix for 306 this throws an Error.
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 1)
@@ -149,7 +149,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'should not generate an error': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 0)
 
@@ -166,7 +166,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'should not generate an error': (source) ->
-            config = {no_unnecessary_double_quotes: {level: 'error'}}
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 0)
 

--- a/test/test_non_empty_constructor_needs_parens.coffee
+++ b/test/test_non_empty_constructor_needs_parens.coffee
@@ -36,12 +36,13 @@ vows.describe(RULE).addBatch({
             config =
                 non_empty_constructor_needs_parens:
                     level: 'error'
+
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 4)
             assert.equal(errors[0].lineNumber, 6)
             assert.equal(errors[1].lineNumber, 7)
             assert.equal(errors[2].lineNumber, 9)
             assert.equal(errors[3].lineNumber, 10)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
 }).export(module)

--- a/test/test_prefer_english_operator.coffee
+++ b/test/test_prefer_english_operator.coffee
@@ -3,7 +3,7 @@ vows = require 'vows'
 assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
-configError = {prefer_english_operator: {level: 'error'}}
+configError = { prefer_english_operator: { level: 'error' } }
 
 RULE = 'prefer_english_operator'
 
@@ -36,11 +36,10 @@ vows.describe(RULE).addBatch({
             assert.equal(result.length, 0)
 
         'can be configred at an independent level': ->
-
-            configError = {prefer_english_operator: {
-                level: 'error'
-                doubleNotLevel: 'warn'
-            }}
+            configError =
+                prefer_english_operator:
+                    level: 'error'
+                    doubleNotLevel: 'warn'
 
             result = coffeelint.lint('x = !!y', configError)
             assert.equal(result.length, 1)

--- a/test/test_space_operators.coffee
+++ b/test/test_space_operators.coffee
@@ -91,15 +91,15 @@ vows.describe(RULE).addBatch({
             '''
 
         'are permitted by default': (source) ->
-            config = {no_nested_string_interpolation: {level: 'ignore'}}
+            config = { no_nested_string_interpolation: { level: 'ignore' } }
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {
-                space_operators: {level: 'error'},
-                no_nested_string_interpolation: {level: 'ignore'}
-            }
+            config =
+                space_operators: { level: 'error' },
+                no_nested_string_interpolation: { level: 'ignore' }
+
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, source.split('\n').length)
             error = errors[0]
@@ -170,10 +170,10 @@ vows.describe(RULE).addBatch({
             '''
 
         'are permitted': (source) ->
-            config = {
-                space_operators: {level: 'error'},
-                no_nested_string_interpolation: {level: 'ignore'}
-            }
+            config =
+                space_operators: { level: 'error' },
+                no_nested_string_interpolation: { level: 'ignore' }
+
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors)
 
@@ -189,12 +189,12 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
         'can be forbidden': (source) ->
-            config = {
-                space_operators: {level: 'error'},
-                no_nested_string_interpolation: {level: 'ignore'}
-            }
+            config =
+                space_operators: { level: 'error' },
+                no_nested_string_interpolation: { level: 'ignore' }
+
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 2)
-            assert.equal(rule, RULE) for {rule} in errors
+            assert.equal(rule, RULE) for { rule } in errors
 
 }).export(module)

--- a/test/test_spacing_after_comma.coffee
+++ b/test/test_spacing_after_comma.coffee
@@ -14,7 +14,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'should not error': (source) ->
-            config = {spacing_after_comma: {level: 'warn'}}
+            config = { spacing_after_comma: { level: 'warn' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
@@ -30,7 +30,7 @@ vows.describe(RULE).addBatch({
             assert.equal(errors.length, 0)
 
         'can be forbidden': (source) ->
-            config = {spacing_after_comma: {level: 'warn'}}
+            config = { spacing_after_comma: { level: 'warn' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 1)
             error = errors[0]
@@ -49,7 +49,7 @@ vows.describe(RULE).addBatch({
             '''
 
         'should not issue warns': (source) ->
-            config = {spacing_after_comma: {level: 'warn'}}
+            config = { spacing_after_comma: { level: 'warn' } }
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 


### PR DESCRIPTION
This enables `braces_spacing` (spaces: 1, empty_object_spaces: 0) for
coffeelint development