### PR TITLE
base_linter: unknown level now returns the rule name

### DIFF
--- a/src/base_linter.coffee
+++ b/src/base_linter.coffee
@@ -19,13 +19,12 @@ module.exports = class BaseLinter
     # Create an error object for the given rule with the given
     # attributes.
     createError: (ruleName, attrs = {}) ->
-
         # Level should default to what's in the config, but can be overridden.
         attrs.level ?= @config[ruleName].level
 
         level = attrs.level
         if level not in ['ignore', 'warn', 'error']
-            throw new Error("unknown level #{level}")
+            throw new Error("unknown level #{level} for rule: #{ruleName}")
 
         if level in ['error', 'warn']
             attrs.rule = ruleName
@@ -46,7 +45,7 @@ module.exports = class BaseLinter
                 if @acceptRule(rule)
                     @rules.push rule
             else if level isnt 'ignore'
-                throw new Error("unknown level #{level}")
+                throw new Error("unknown level #{level} for rule: #{rule}")
 
     normalizeResult: (p, result) ->
         if result is true


### PR DESCRIPTION
If you generate an unknown level error, it now returns the name of the
rule that has the bad level setting.