### PR TITLE
Move $COFFEELINT_CONFIG into configfinder

### DIFF
--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -95,9 +95,6 @@ loadConfig = (options) ->
             # If -f was specifying a package.json, extract the config
             if config.coffeelintConfig
                 config = config.coffeelintConfig
-        else if (process.env.COFFEELINT_CONFIG and
-                fs.existsSync(process.env.COFFEELINT_CONFIG))
-            config = readConfigFile(process.env.COFFEELINT_CONFIG)
     config
 
 # Get fallback configuration. With the -F flag found configs in standard places

--- a/src/configfinder.coffee
+++ b/src/configfinder.coffee
@@ -43,6 +43,9 @@ loadJSON = (filename) ->
 # specific 'coffeelint.json' or a global 'coffeelint.json' in the home
 # directory.
 getConfig = (dir) ->
+    if (process.env.COFFEELINT_CONFIG and
+            fs.existsSync(process.env.COFFEELINT_CONFIG))
+        return loadJSON(process.env.COFFEELINT_CONFIG)
 
     npmConfig = loadNpmConfig(dir)
     return npmConfig  if npmConfig


### PR DESCRIPTION
I think it makes more sense to move this than to re-implement it over in [linter-coffeelint](https://github.com/AtomLinter/linter-coffeelint/issues/51#issuecomment-151946844)