### PR TITLE
Allow direct loading of .coffee modules

### DIFF
--- a/src/commandline.coffee
+++ b/src/commandline.coffee
@@ -139,7 +139,8 @@ reportAndExit = (errorReport, options) ->
     SelectedReporter = coreReporters[strReporter] ? do ->
         try
             reporterPath = resolve strReporter, {
-                basedir: process.cwd()
+                basedir: process.cwd(),
+                extensions: ['.js', '.coffee', '.litcoffee', '.coffee.md']
             }
         catch
             reporterPath = strReporter

--- a/src/configfinder.coffee
+++ b/src/configfinder.coffee
@@ -65,7 +65,8 @@ expandModuleNames = (dir, config) ->
     for ruleName, data of config when data?.module?
         config[ruleName]._module = config[ruleName].module
         config[ruleName].module = resolve data.module, {
-            basedir: dir
+            basedir: dir,
+            extensions: ['.js', '.coffee', '.litcoffee', '.coffee.md']
         }
 
     coffeelint = config.coffeelint
@@ -73,12 +74,14 @@ expandModuleNames = (dir, config) ->
         coffeelint._transforms = coffeelint.transforms
         coffeelint.transforms = coffeelint.transforms.map (moduleName) ->
             return resolve moduleName, {
-                basedir: dir
+                basedir: dir,
+                extensions: ['.js', '.coffee', '.litcoffee', '.coffee.md']
             }
     if coffeelint?.coffeescript?
         coffeelint._coffeescript = coffeelint.coffeescript
         coffeelint.coffeescript = resolve coffeelint.coffeescript, {
-            basedir: dir
+            basedir: dir,
+            extensions: ['.js', '.coffee', '.litcoffee', '.coffee.md']
         }
 
     config

--- a/src/ruleLoader.coffee
+++ b/src/ruleLoader.coffee
@@ -7,7 +7,8 @@ module.exports =
         try
             # Try to find the project-level rule first.
             rulePath = resolve moduleName, {
-                basedir: process.cwd()
+                basedir: process.cwd(),
+                extensions: ['.js', '.coffee', '.litcoffee', '.coffee.md']
             }
             return require rulePath
         try


### PR DESCRIPTION
[A couple](https://github.com/bsklaroff/coffeelint-camel-case-vars) of older [custom rules](https://github.com/begizi/coffeelint-limit-newlines) written for coffeelint are written in coffeescript and are not compiled to js prior to publishing to npm. While this is technically an issue with the modules themselves (especially when they advertise an inexistent `index.js` as an entry point), I see no reason coffeelint couldn't be more coffeescript friendly, given its scope.

This patch instructs `resolve` to also accept coffee and litcofee files and thus prevent issues like this:

```
Error: Cannot find module 'coffeelint-limit-newlines' from 'B:\node-luacheck\src'
  at module.exports (B:\node-luacheck\node_modules\coffeelint\node_modules\resolve\lib\sync.js:32:11)
  at expandModuleNames (B:\node-luacheck\node_modules\coffeelint\lib\configfinder.js:84:33)
  at Object.exports.getConfig (B:\node-luacheck\node_modules\coffeelint\lib\configfinder.js:137:16)
  at getFallbackConfig (B:\node-luacheck\node_modules\coffeelint\lib\commandline.js:140:27)
  at lintFiles (B:\node-luacheck\node_modules\coffeelint\lib\commandline.js:95:38)
  at Object.<anonymous> (B:\node-luacheck\node_modules\coffeelint\lib\commandline.js:247:21)
  at Object.<anonymous> (B:\node-luacheck\node_modules\coffeelint\lib\commandline.js:252:4)
  at Module._compile (module.js:410:26)
  at Object.Module._extensions..js (module.js:417:10)
  at Module.load (module.js:344:32)
  at Function.Module._load (module.js:301:12)
  at Module.require (module.js:354:17)
  at require (internal/module.js:12:17)
  at Object.<anonymous> (C:\Users\Radu\AppData\Roaming\npm\node_modules\coffeelint\bin\coffeelint:34:5)
  at Module._compile (module.js:410:26)
  at Object.Module._extensions..js (module.js:417:10)
  at Module.load (module.js:344:32)
  at Function.Module._load (module.js:301:12)
  at Function.Module.runMain (module.js:442:10)
  at startup (node.js:136:18)
  at node.js:966:3
```