### PR TITLE
Better directive handling

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -298,7 +298,7 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
     disabledInitially = []
     # Check ahead for inline enabled rules
     for l in source.split('\n')
-        [ regex, set, ..., rule ] = LineLinter.configStatement.exec(l) or []
+        [ regex, set, ..., rule ] = LineLinter.getDirective(l) or []
         if set in ['enable', 'enable-line'] and config[rule]?.level is 'ignore'
             disabledInitially.push rule
             config[rule].level = 'error'

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -52,14 +52,19 @@ extend = (destination, sources...) ->
 defaults = (source, defaults) ->
     extend({}, defaults, source)
 
+# Helper to add rules to disabled list
+union = (a, b) ->
+    c = {}
+    for x in a
+        c[x] = true
+    for x in b
+        c[x] = true
+
+    x for x of c
+
 # Helper to remove rules from disabled list
 difference = (a, b) ->
-    j = 0
-    while j < a.length
-        if a[j] in b
-            a.splice(j, 1)
-        else
-            j++
+    x for x in a when x not in b
 
 LineLinter = require './line_linter.coffee'
 LexicalLinter = require './lexical_linter.coffee'
@@ -336,10 +341,12 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
             rules = inlineConfig[cmd][i]
             {
                 'disable': ->
-                    disabled = disabled.concat(rules)
+                    disabled = union(disabled, rules)
                 'enable': ->
-                    difference(disabled, rules)
-                    disabled = disabledInitially if rules.length is 0
+                    if rules.length
+                        disabled = difference(disabled, rules)
+                    else
+                        disabled = disabledInitially
             }[cmd]() if rules?
         # advance line and append relevant messages
         while nextLine is i and allErrors.length > 0

--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -333,6 +333,16 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
     # Sort by line number and return.
     errors.sort((a, b) -> a.lineNumber - b.lineNumber)
 
+    # Create a list of all errors
+    disabledEntirely = do ->
+        result = []
+        map = {}
+        for { name } in errors or []
+            if not map[name]
+                result.push(name)
+                map[name] = true
+        result
+
     # Disable/enable rules for inline blocks
     allErrors = errors
     errors = []
@@ -344,9 +354,16 @@ coffeelint.lint = (source, userConfig = {}, literate = false) ->
             rules = inlineConfig[cmd][i]
             {
                 'disable': ->
-                    disabled = union(disabled, rules)
+                    if rules.length
+                        disabled = union(disabled, rules)
+                        disabledLine = union(disabledLine, rules)
+                    else
+                        disabled = disabledLine = disabledEntirely
                 'disable-line': ->
-                    disabledLine = disabledLine.concat(rules)
+                    if rules.length
+                        disabledLine = union(disabledLine, rules)
+                    else
+                        disabledLine = disabledEntirely
                 'enable': ->
                     if rules.length
                         disabled = difference(disabled, rules)

--- a/src/line_linter.coffee
+++ b/src/line_linter.coffee
@@ -69,7 +69,7 @@ class LineApi
 BaseLinter = require './base_linter.coffee'
 
 # Some repeatedly used regular expressions.
-configStatement = /coffeelint:\s*(disable|enable)(?:=([\w\s,]*))?/
+configStatement = /coffeelint:\s*((disable|enable)(-line)?)(?:=([\w\s,]*))?/
 
 #
 # A class that performs regex checks on each line of the source.
@@ -88,6 +88,8 @@ module.exports = class LineLinter extends BaseLinter
         @inlineConfig =
             enable: {}
             disable: {}
+            'enable-line': {}
+            'disable-line': {}
 
     acceptRule: (rule) ->
         return typeof rule.lintLine is 'function'
@@ -121,8 +123,8 @@ module.exports = class LineLinter extends BaseLinter
         if result?
             cmd = result[1]
             rules = []
-            if result[2]?
-                for r in result[2].split(',')
+            if result[4]?
+                for r in result[4].split(',')
                     rules.push r.replace(/^\s+|\s+$/g, '')
             @inlineConfig[cmd][@lineNumber] = rules
         return null

--- a/test/test_comment_config.coffee
+++ b/test/test_comment_config.coffee
@@ -49,7 +49,7 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[1].lineNumber, 3)
             assert.ok(errors[1].message)
 
-    'Enable all statements':
+    'Revert to post-config state':
         topic: () ->
             '''
             # coffeelint: disable=no_trailing_semicolons,no_implicit_parens

--- a/test/test_comment_config.coffee
+++ b/test/test_comment_config.coffee
@@ -25,6 +25,26 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[0].lineNumber, 5)
             assert.ok(errors[0].message)
 
+    'Disable all statements':
+        topic: () ->
+            '''
+            # coffeelint: disable
+            a 'you get a semi-colon';
+            b 'you get a semi-colon';
+            # coffeelint: enable
+            c 'everybody gets a semi-colon';
+            '''
+
+        'can disable rules in your config': (source) ->
+            config =
+                no_trailing_semicolons: level: 'error'
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].rule, 'no_trailing_semicolons')
+            assert.equal(errors[0].level, 'error')
+            assert.equal(errors[0].lineNumber, 5)
+            assert.ok(errors[0].message)
+
     'Disable statements per line':
         topic: () ->
             '''
@@ -41,6 +61,28 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[0].level, 'error')
             assert.equal(errors[0].lineNumber, 2)
             assert.ok(errors[0].message)
+
+    'Disable all statements per line':
+        topic: () ->
+            '''
+            a 'foo';  # coffeelint: disable-line
+            b 'bar';
+            '''
+
+        'can disable rules in your config': (source) ->
+            config =
+                no_trailing_semicolons: level: 'error'
+                no_implicit_parens: level: 'error'
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 2)
+            assert.equal(errors[0].rule, 'no_implicit_parens')
+            assert.equal(errors[0].level, 'error')
+            assert.equal(errors[0].lineNumber, 2)
+            assert.ok(errors[0].message)
+            assert.equal(errors[1].rule, 'no_trailing_semicolons')
+            assert.equal(errors[1].level, 'error')
+            assert.equal(errors[1].lineNumber, 2)
+            assert.ok(errors[1].message)
 
     'Enable statements':
         topic: () ->

--- a/test/test_comment_config.coffee
+++ b/test/test_comment_config.coffee
@@ -62,6 +62,23 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[0].lineNumber, 2)
             assert.ok(errors[0].message)
 
+    'Expand shortcuts':
+        topic: () ->
+            '''
+            a 'foo';  # noqa
+            b 'bar';
+            '''
+
+        'will expand and honor directive shortcuts': (source) ->
+            config =
+                no_trailing_semicolons: level: 'error'
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].rule, 'no_trailing_semicolons')
+            assert.equal(errors[0].level, 'error')
+            assert.equal(errors[0].lineNumber, 2)
+            assert.ok(errors[0].message)
+
     'Disable all statements per line':
         topic: () ->
             '''

--- a/test/test_comment_config.coffee
+++ b/test/test_comment_config.coffee
@@ -25,6 +25,23 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[0].lineNumber, 5)
             assert.ok(errors[0].message)
 
+    'Disable statements per line':
+        topic: () ->
+            '''
+            a 'foo';  # coffeelint: disable-line=no_trailing_semicolons
+            b 'bar';
+            '''
+
+        'can disable rules in your config': (source) ->
+            config =
+                no_trailing_semicolons: level: 'error'
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].rule, 'no_trailing_semicolons')
+            assert.equal(errors[0].level, 'error')
+            assert.equal(errors[0].lineNumber, 2)
+            assert.ok(errors[0].message)
+
     'Enable statements':
         topic: () ->
             '''
@@ -48,6 +65,22 @@ vows.describe('comment_config').addBatch({
             assert.equal(errors[1].level, 'error')
             assert.equal(errors[1].lineNumber, 3)
             assert.ok(errors[1].message)
+
+    'Enable statements per line':
+        topic: () ->
+            '''
+            a 'foo'
+            b 'bar'  # coffeelint: enable-line=no_implicit_parens
+            c 'baz'
+            '''
+
+        'can enable rules not in your config': (source) ->
+            errors = coffeelint.lint(source)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].rule, 'no_implicit_parens')
+            assert.equal(errors[0].level, 'error')
+            assert.equal(errors[0].lineNumber, 2)
+            assert.ok(errors[0].message)
 
     'Revert to post-config state':
         topic: () ->


### PR DESCRIPTION
Closes #540 

Changes:

1. Changes the semantics of `coffeelint-enable`:

  *From*: enables all rules that were previously disabled by a `coffeelint-disable` directive
  *To*: resets the ruleset to whatever was originally specified in `coffeelint.json`

  This is because the current implementation is buggy and mixes immutable with mutable structures. While there are ways around this, it makes the code needlessly complex and not that much useful.

  Example of existing bug

  ```coffeescript
# coffeelint: enable=no_implicit_parens
# coffeelint: disable=no_implicit_parens
# coffeelint: enable
foo "bar"  # error
```

  ```coffeescript
# coffeelint: disable=no_implicit_parens
# coffeelint: enable=no_implicit_parens
# coffeelint: disable=no_implicit_parens
# coffeelint: enable
foo "bar"  # no error
  ```

2. Adds the following directives that work like their parents but only for the current line

  * `coffeelint-disable-line=foo,bar,baz`
  * `coffeelint-enable-line=foo,bar,baz`

3. Overloads `coffeelint-disable` to disable all registered rules. Primary use case:

   ```coffeescript
  # coffeelint: disable
  do bad shit here
  # coffeelint: enable
  ```

  This contrasts with the primary use case for the parametric version which is:

  ```coffeescript
  # coffeelint: disable=foo
  do shit "foo" would complain about
  # coffeelint: enable=foo
  ```

4. Adds support for directive shortcuts. Also defines the first shortcut `# noqa` that expands into `coffeelint: disable-line`