### PR TITLE
Upgrade node-ignore -> 3.x to solve several known issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "^1.9.1",
     "coffeeify": "~1.0.0",
     "glob": "^4.0.0",
-    "ignore": "^2.2.15",
+    "ignore": "^3.0.9",
     "optimist": "^0.6.1",
     "resolve": "^0.6.3",
     "strip-json-comments": "^1.0.2"


### PR DESCRIPTION
Upgrades [`node-ignore`](https://www.npmjs.com/package/ignore) to the latest `3.0.9` to solve several known issues, including:

- Files should not be re-included if the parent directory is ignored, [#10](https://github.com/kaelzhang/node-ignore/issues/10)
- Works for [windows](https://ci.appveyor.com/project/kaelzhang/node-ignore), finally. [#5](https://github.com/kaelzhang/node-ignore/issues/5)
- Better Handling with trailing whitespaces, wildcards of ignore patterns, according to [gitignore spec](https://git-scm.com/docs/gitignore), and passed all cases described in the spec.