### PR TITLE
Support for tab indented literate files added

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -126,17 +126,18 @@ coffeelint.trimConfig = (userConfig) ->
 
 coffeelint.invertLiterate = (source) ->
     source = CoffeeScript.helpers.invertLiterate source
-    # Strip the first 4 spaces from every line. After this the markdown is
-    # commented and all of the other code should be at their natural location.
+    # Strip the first 4 spaces or a tab from every line.
+    # After this the markdown is commented and all of the other code
+    # should be at their natural location.
     newSource = ''
     for line in source.split '\n'
         if line.match(/^#/)
             # strip trailing space
             line = line.replace /\s*$/, ''
-        # Strip the first 4 spaces of every line. This is how Markdown
+        # Strip the first 4 spaces or a tab of every line. This is how Markdown
         # indicates code, so in the end this pulls everything back to where it
         # would be indented if it hadn't been written in literate style.
-        line = line.replace /^\s{4}/g, ''
+        line = line.replace /^\s{4}|^\t/g, ''
         newSource += "#{line}\n"
 
     newSource

--- a/test/test_literate.litcoffee
+++ b/test/test_literate.litcoffee
@@ -19,8 +19,10 @@ Markdown uses trailing spaces to force a line break.
 The line of code is written weird because I had trouble getting the 4 space
 prefix in place.
 
+The third line in this topic is used to test support for a trailing tab whitespace.
+
                 """This is some `Markdown`.  \n\n
-                \n    x = 1234  \n    y = 1
+                \n    x = 1234  \n    y = 1  \n	z = 1
                 """
 
             'is ignored' : (source) ->
@@ -32,6 +34,6 @@ The 3rd parameter here indicates that the incoming source is literate.
 This intentionally includes trailing whitespace in code so it also verifies
 that the way `Markdown` spaces are stripped are not also stripping code.
 
-                assert.equal(errors.length, 1)
+                assert.equal(errors.length, 2)
 
     }).export(module)


### PR DESCRIPTION
This PR adds support for trailing tab whitespace in literate files.
See #557 for more.