### PR TITLE
Tabs indented literate code fixed

### DIFF
--- a/src/coffeelint.coffee
+++ b/src/coffeelint.coffee
@@ -137,7 +137,7 @@ coffeelint.invertLiterate = (source) ->
         # Strip the first 4 spaces or a tab of every line. This is how Markdown
         # indicates code, so in the end this pulls everything back to where it
         # would be indented if it hadn't been written in literate style.
-        line = line.replace /^\s{4}|^\t/g, ''
+        line = line.replace /^ {4}|^\t/g, ''
         newSource += "#{line}\n"
 
     newSource

--- a/test/test_literate.litcoffee
+++ b/test/test_literate.litcoffee
@@ -19,10 +19,8 @@ Markdown uses trailing spaces to force a line break.
 The line of code is written weird because I had trouble getting the 4 space
 prefix in place.
 
-The third line in this topic is used to test support for a trailing tab whitespace.
-
                 """This is some `Markdown`.  \n\n
-                \n    x = 1234  \n    y = 1  \n	z = 1
+                \n    x = 1234  \n    y = 1
                 """
 
             'is ignored' : (source) ->
@@ -34,6 +32,22 @@ The 3rd parameter here indicates that the incoming source is literate.
 This intentionally includes trailing whitespace in code so it also verifies
 that the way `Markdown` spaces are stripped are not also stripping code.
 
-                assert.equal(errors.length, 2)
+                assert.equal(errors.length, 1)
+
+        'Tab indented markdown' :
+
+            topic:
+
+Second line in this topic is used to test support for a tab indented lines.
+Third line verifies that only a first tab is removed.
+
+                """This is some `Markdown`.\n\n
+                \n	x = 1\n				y = 1
+                """
+
+            'is ignored' : (source) ->
+
+                errors = coffeelint.lint(source, {}, true)
+                assert.equal(errors.length, 3)
 
     }).export(module)


### PR DESCRIPTION
In the previous PR #557 I forgot that `\s` in RegExp matches also tab characters.
Right now lines with 4 and more tabs occurs in `unexpected indentation` code, because first four tabs are removing.
This PR fixes this bug.