### PR TITLE
Fix misleading information about plugins API

### DIFF
--- a/index-bottom.html
+++ b/index-bottom.html
@@ -104,7 +104,7 @@
               <code>
                   lintLine(line, lineApi)<br/>
                   lintToken(token, tokenApi)<br>
-                  lintNode(node, astApi)
+                  lintAPI(ast, astApi)
               </code>
 
               The second parameter of each is an object with helper functions.

--- a/index.html
+++ b/index.html
@@ -775,7 +775,7 @@ and warns that line numbers are probably incorrect.
               <code>
                   lintLine(line, lineApi)<br/>
                   lintToken(token, tokenApi)<br>
-                  lintNode(node, astApi)
+                  lintAPI(ast, astApi)
               </code>
 
               The second parameter of each is an object with helper functions.


### PR DESCRIPTION
<img width="766" alt="tmux___users_koss_src_kossnocorp_coffeelint-mocha" src="https://cloud.githubusercontent.com/assets/52201/15492012/2684412a-21a9-11e6-89c5-5f430a38abc7.png">

...but:

<img width="800" alt="coffeelint_-_lint_your_coffeescript" src="https://cloud.githubusercontent.com/assets/52201/15492018/39975ad6-21a9-11e6-900e-8e7bb81874bf.png">
