### PR TITLE
Make tests pass with latest master of CoffeeScript

### DIFF
--- a/src/rules/duplicate_key.coffee
+++ b/src/rules/duplicate_key.coffee
@@ -12,7 +12,7 @@ module.exports = class DuplicateKey
             Prevents defining duplicate keys in object literals and classes
             '''
 
-    tokens: ['IDENTIFIER', '{', '}']
+    tokens: ['IDENTIFIER', 'PROPERTY', '{', '}']
 
     constructor: ->
         @braceScopes = []   # A stack tracking keys defined in nexted scopes.
@@ -23,7 +23,7 @@ module.exports = class DuplicateKey
             @lintBrace arguments...
             return undefined
 
-        if type is 'IDENTIFIER'
+        if type in ['IDENTIFIER', 'PROPERTY']
             @lintIdentifier arguments...
 
     lintIdentifier: (token, tokenApi) ->

--- a/src/rules/empty_constructor_needs_parens.coffee
+++ b/src/rules/empty_constructor_needs_parens.coffee
@@ -19,7 +19,7 @@ module.exports = class EmptyConstructorNeedsParens
             loop
                 expectedIdentifier = peek(identifierIndex)
                 expectedCallStart  = peek(identifierIndex + 1)
-                if expectedIdentifier?[0] is 'IDENTIFIER'
+                if expectedIdentifier?[0] in ['IDENTIFIER', 'PROPERTY']
                     if expectedCallStart?[0] is '.'
                         # skip the dot and start with the next token
                         identifierIndex += 2
@@ -34,7 +34,7 @@ module.exports = class EmptyConstructorNeedsParens
             # The callStart is generated if your parameters are all on the same
             # line with implicit parens, and if your parameters start on the
             # next line, but is missing if there are no params and no parens.
-            if expectedIdentifier?[0] is 'IDENTIFIER' and expectedCallStart?
+            if expectedIdentifier?[0] in ['IDENTIFIER', 'PROPERTY'] and expectedCallStart?
                 return @handleExpectedCallStart expectedCallStart
 
     handleExpectedCallStart: (expectedCallStart) ->

--- a/src/rules/no_debugger.coffee
+++ b/src/rules/no_debugger.coffee
@@ -10,10 +10,10 @@ module.exports = class NoDebugger
             This rule is `warn` by default.
             '''
 
-    tokens: ['DEBUGGER', 'IDENTIFIER']
+    tokens: ['STATEMENT', 'DEBUGGER', 'IDENTIFIER', 'PROPERTY']
 
     lintToken: (token, tokenApi) ->
-        if token[0] is 'DEBUGGER'
+        if token[0] in ['DEBUGGER', 'STATEMENT'] and token[1] is 'debugger'
             return { context: "found '#{token[0]}'" }
 
         if tokenApi.config[@rule.name]?.console

--- a/src/rules/no_implicit_braces.coffee
+++ b/src/rules/no_implicit_braces.coffee
@@ -23,7 +23,7 @@ module.exports = class NoImplicitBraces
             idiomatic CoffeeScript.
             '''
 
-    tokens: ['{', 'OUTDENT', 'CLASS', 'IDENTIFIER', 'EXTENDS']
+    tokens: ['{', 'OUTDENT', 'CLASS', 'IDENTIFIER', 'PROPERTY', 'EXTENDS']
 
     constructor: ->
         @isClass = false
@@ -42,10 +42,10 @@ module.exports = class NoImplicitBraces
         # If we're looking at an IDENTIFIER, and we're in a class, and we've not
         # set a className (or the previous non-identifier was 'EXTENDS', set the
         # current identifier as the class name)
-        if type is 'IDENTIFIER' and @isClass and @className is ''
+        if type in ['IDENTIFIER', 'PROPERTY'] and @isClass and @className is ''
             # Backtrack to get the full classname
             c = 0
-            while tokenApi.peek(c)[0] in ['IDENTIFIER', '.']
+            while tokenApi.peek(c)[0] in ['IDENTIFIER', 'PROPERTY', '.']
                 @className += tokenApi.peek(c)[1]
                 c++
 
@@ -69,9 +69,10 @@ module.exports = class NoImplicitBraces
 
                 peekIdent = ''
                 c = -2
-                # Go back until you grab all the tokens with IDENTIFIER or '.'
+                # Go back until you grab all the tokens with IDENTIFIER,
+                # PROPERTY or '.'
                 while ([_type, _val] = tokenApi.peek(c))
-                    break if _type not in ['IDENTIFIER', '.']
+                    break if _type not in ['IDENTIFIER', 'PROPERTY', '.']
                     peekIdent = _val + peekIdent
                     c--
 

--- a/src/rules/no_stand_alone_at.coffee
+++ b/src/rules/no_stand_alone_at.coffee
@@ -17,7 +17,7 @@ module.exports = class NoStandAloneAt
     lintToken: (token, tokenApi) ->
         nextToken = tokenApi.peek()
         spaced = token.spaced
-        isIdentifier = nextToken[0] is 'IDENTIFIER'
+        isIdentifier = nextToken[0] in ['IDENTIFIER', 'PROPERTY']
         isIndexStart = nextToken[0] is 'INDEX_START'
         isDot = nextToken[0] is '.'
 
@@ -27,7 +27,7 @@ module.exports = class NoStandAloneAt
         # sense to group it into no_stand_alone_at
         if nextToken[0] is '::'
             protoProperty = tokenApi.peek(2)
-            isValidProtoProperty = protoProperty[0] is 'IDENTIFIER'
+            isValidProtoProperty = protoProperty[0] in ['IDENTIFIER', 'PROPERTY']
 
         if spaced or (not isIdentifier and not isIndexStart and
                 not isDot and not isValidProtoProperty)

--- a/src/rules/no_unnecessary_fat_arrows.coffee
+++ b/src/rules/no_unnecessary_fat_arrows.coffee
@@ -27,6 +27,7 @@ module.exports = class NoUnnecessaryFatArrows
     isValue: (node) -> @astApi.getNodeName(node) is 'Value'
 
     isThis: (node) =>
+        node.constructor?.name is 'ThisLiteral' or
         @isValue(node) and node.base.value is 'this'
 
 
@@ -36,7 +37,8 @@ module.exports = class NoUnnecessaryFatArrows
             node.body.contains(@isThis)? or
             node.body.contains((child) =>
                 unless @astApi.getNodeName(child)
-                    child.isSuper? and child.isSuper
+                    child.constructor?.name is 'SuperCall' or
+                    (child.isSuper? and child.isSuper)
                 else
                     @isFatArrowCode(child) and @needsFatArrow(child))?
         )


### PR DESCRIPTION
Tested with jashkenas/coffeescript commit d7e752b.

They also still pass with latest stable CoffeeScript (1.10.0).

1. Run `npm test` as usual to verify that it works with CoffeeScript 0.10.0.
2. Install latest master of CoffeeScript and run `npm test`.

NOTE: The most common change in this PR is adding checks for the new 'PROPERTY' around code that looks for the 'IDENTIFIER' token. There are more occurances of 'IDENTIFIER' in the code that I have NOT touched. I simply worked until all tests passed. I'm not sure if these cases need modifying or not. If they do, the tests need to be updated to cover it. I'd like some help from a more experienced coffeelint developer here.