### PR TITLE
update glob and browserify to fix minimatch security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "coffeelint": "./bin/coffeelint"
   },
   "dependencies": {
-    "browserify": "~8.1.0",
+    "browserify": "^13.1.0",
     "coffee-script": "~1.10.0",
     "coffeeify": "~1.0.0",
-    "glob": "^4.0.0",
+    "glob": "^7.0.6",
     "ignore": "^3.0.9",
     "optimist": "^0.6.1",
     "resolve": "^0.6.3",


### PR DESCRIPTION
Reduce the scope of https://github.com/clutchski/coffeelint/pull/573

Resolves security issues with old nested minimatch dependencies. Vows [still hasn't updated to a newer minimatch](https://github.com/vowsjs/vows/issues/370) but it is a development dependency so that shouldn't cause any issues.