### PR TITLE
Quoted duplicate key detection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.coffee]
+indent_style = space
+indent_size = 4
+charset = utf-8

--- a/src/rules/duplicate_key.coffee
+++ b/src/rules/duplicate_key.coffee
@@ -13,7 +13,7 @@ module.exports = class DuplicateKey
             '''
 
     # TODO: after <1.10.0 is not supported, remove 'IDENTIFIER' here
-    tokens: ['IDENTIFIER', 'PROPERTY', '{', '}']
+    tokens: ['IDENTIFIER', 'PROPERTY', 'STRING', '{', '}']
 
     constructor: ->
         @braceScopes = []   # A stack tracking keys defined in nexted scopes.
@@ -25,7 +25,7 @@ module.exports = class DuplicateKey
             return undefined
 
         # TODO: after <1.10.0 is not supported, remove 'IDENTIFIER' here
-        if type in ['IDENTIFIER', 'PROPERTY']
+        if type in ['IDENTIFIER', 'PROPERTY', 'STRING']
             @lintIdentifier arguments...
 
     lintIdentifier: (token, tokenApi) ->
@@ -43,6 +43,9 @@ module.exports = class DuplicateKey
 
         # Assigning "@something" and "something" are not the same thing
         key = "@#{key}" if previousToken[0] is '@'
+
+        # Normalize property, "property", and 'property'
+        key = m[2] if m = key.match /^(["'])(.*)\1$/
 
         # Added a prefix to not interfere with things like "constructor".
         key = "identifier-#{key}"

--- a/test/test_arrow_spacing.coffee
+++ b/test/test_arrow_spacing.coffee
@@ -189,7 +189,7 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source, config)
             assert.isEmpty(errors, 0)
 
-    'Handle a nested arrow at end of file':
+    'Handle a nested arrow at beginning & end of file':
         topic:
             '''
             class A\n  f: ->

--- a/test/test_duplicate_key.coffee
+++ b/test/test_duplicate_key.coffee
@@ -18,6 +18,8 @@ vows.describe(RULE).addBatch({
                   keyA: one
                   keyB: one
                   keyA: 2
+                  "keyC": 42
+                  'keyC': 42
               getConfig: ->
                 @config =
                   foo: 1
@@ -33,13 +35,17 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source)
             # Verify the two actual duplicate keys are found and it is not
             # mistaking @getConfig as a duplicate key
-            assert.equal(errors.length, 2)
+            assert.equal(errors.length, 3)
             error = errors[0]
-            assert.equal(error.lineNumber, 8) # 2nd getA
+            assert.equal(error.lineNumber, 8) # 2nd keyA
             assert.equal(error.message, message)
             assert.equal(error.rule, RULE)
             error = errors[1]
-            assert.equal(error.lineNumber, 9) # 2nd getConfig
+            assert.equal(error.lineNumber, 10) # 2nd keyC
+            assert.equal(error.message, message)
+            assert.equal(error.rule, RULE)
+            error = errors[2]
+            assert.equal(error.lineNumber, 11) # 2nd getConfig
             assert.equal(error.message, message)
             assert.equal(error.rule, RULE)
 


### PR DESCRIPTION
Currently this will pass the `duplicate_key` test:
```coffee
x =
  'a': 42
  'a': 42
```

With this fix, that is a `duplicate_key` error, as are things like:
```coffee
x =
  b: 42
  "b": 42
```

Threw in a 4-space-indent `.editorconfig` to keep everyone editing on the same page.

New lint rule found a quoted duplicate key in `test/test_arrow_spacing.coffee` :-)