### PR TITLE
Add failing tests for indentation lint bug

### DIFF
--- a/test/test_indentation.coffee
+++ b/test/test_indentation.coffee
@@ -153,6 +153,28 @@ vows.describe(RULE).addBatch({
         'is permitted': (source) ->
             assert.isEmpty(coffeelint.lint(source))
 
+    'Consecutive chained invocations with a prop method call':
+        topic:
+            '''
+            $('<input>')
+                .addClass('k')
+                .prop('placeholder', @$el.prop('placeholder'))
+                .hide()
+            '''
+
+        'is permitted': (source) ->
+            assert.isEmpty(coffeelint.lint(source))
+
+    'Consecutive chained invocations with string concatenation':
+        topic:
+            '''
+            $('body')
+                .addClass("hello-" + world).addClass("red")
+            '''
+
+        'is permitted': (source) ->
+            assert.isEmpty(coffeelint.lint(source))
+
     'Consecutive indented chained invocations and multi-line expression':
         topic:
             '''


### PR DESCRIPTION
This test shows a bug introduced in 1.16.1 (not existent in 1.16.0). Only seems to happen based on using the `prop` function in some instances:

```coffeescript
# OK
$('<input>')
  .prop('placeholder', $el.prop('placeholder'))

# OK
$('<input>')
  .prop('placeholder', @$el.attr('placeholder'))

# Fails
$('<input>')
  .prop('placeholder', window.prop('placeholder'))

# Fails
$('<input>')
  .prop('placeholder', @$el.prop('placeholder'))

# ---

# OK
$("body")
  .addClass("alpha--" + beta)
  .addClass("charlie")

# Fails
$("body")
  .addClass("alpha--" + beta).addClass("charlie")
```

Both issues are regressions as they worked in 1.16.0. Not sure as to the fix, but there was a large refactor of the indentation in 1.16.1
