### PR TITLE
Allow any CoffeeScript version above 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "browserify": "^13.1.0",
     "coffeeify": "~1.0.0",
-    "coffeescript": "2.0.0",
+    "coffeescript": "~2.0.0",
     "glob": "^7.0.6",
     "ignore": "^3.0.9",
     "optimist": "^0.6.1",


### PR DESCRIPTION
`CoffeeScript` has newer versions with fixes and features, so `CoffeeLint` should not fix the version used.