### PR TITLE
Reject tabs at end of line

### DIFF
--- a/src/rules/no_tabs.coffee
+++ b/src/rules/no_tabs.coffee
@@ -19,5 +19,7 @@ module.exports = class NoTabs
         indentation = line.split(indentationRegex)[0]
         if lineApi.lineHasToken() and '\t' in indentation
             true
+        else if lineApi.lineHasToken() and line.match(/\t *$/)
+            true
         else
             null

--- a/test/test_coffeelint.coffee
+++ b/test/test_coffeelint.coffee
@@ -13,7 +13,7 @@ vows.describe('coffeelint').addBatch({
 
     "CoffeeLint's errors":
         topic: () -> coffeelint.lint '''
-            a = () ->\t
+            a = () =>
                 1234
             '''
 

--- a/test/test_no_tabs.coffee
+++ b/test/test_no_tabs.coffee
@@ -13,11 +13,12 @@ vows.describe(RULE).addBatch({
             x = () ->
             \ty = () ->
             \t\treturn 1234
+            z = 1\t
             '''
 
         'can be forbidden': (source) ->
             errors = coffeelint.lint(source)
-            assert.equal(errors.length, 4)
+            assert.equal(errors.length, 6)
             error = errors[1]
             assert.equal(error.lineNumber, 2)
             assert.equal(error.message, 'Line contains tab indentation')
@@ -27,15 +28,18 @@ vows.describe(RULE).addBatch({
             config =
                 no_tabs: { level: 'ignore' }
                 indentation: { level: 'error', value: 1 }
+                no_trailing_whitespace: { level: 'ignore' }
 
             errors = coffeelint.lint(source, config)
             assert.equal(errors.length, 0)
 
         'are forbidden by default': (source) ->
-            config = indentation: { level: 'error', value: 1 }
+            config =
+              indentation: { level: 'error', value: 1 }
+              no_trailing_whitespace: { level: 'ignore' }
             errors = coffeelint.lint(source, config)
             assert.isArray(errors)
-            assert.equal(errors.length, 2)
+            assert.equal(errors.length, 3)
             assert.equal(rule, RULE) for { rule } in errors
 
         'are allowed in strings': () ->

--- a/test/test_no_trailing_whitespace.coffee
+++ b/test/test_no_trailing_whitespace.coffee
@@ -107,7 +107,7 @@ vows.describe(RULE).addBatch({
 
         'are forbidden as well': (source) ->
             errors = coffeelint.lint(source)
-            assert.equal(errors.length, 1)
+            assert.equal(errors.length, 2)
 
     'Windows line endings':
         topic:


### PR DESCRIPTION
We have a large coffeescript code base, and had `no_tabs` enabled, but hadn't gotten around to enabling `no_trailing_whitespace`.  I was a bit surprised to learn that there were tabs at the end of lines that coffeelint hadn't caught in the code base.

I see that the `no_tabs` rule is conservative because `no_trailing_whitespace` catches this situation, so feel free to reject.

Thanks for keeping this project going, Shuan!