### PR TITLE
Fix conditional printing of context

### DIFF
--- a/src/reporters/checkstyle.coffee
+++ b/src/reporters/checkstyle.coffee
@@ -26,11 +26,13 @@ module.exports = class CheckstyleReporter
 
                     # context is optional, this avoids generating the string
                     # "context: undefined"
-                    context = e.context ? ''
+                    context =
+                      if e.context then "; context: #{e.context}"
+                      else ''
                     @print """
                     <error line="#{e.lineNumber}"
                         severity="#{@escape(level)}"
-                        message="#{@escape(e.message+'; context: '+context)}"
+                        message="#{@escape(e.message+context)}"
                         source="coffeelint"/>
                     """
                 @print '</file>'


### PR DESCRIPTION
Hello,

I noticed that the “; context: …” string printed by the `checkstyle` reporter might not list a context, which can make the error messages look awkward.

e.g., error messages like this will be printed:

```
Line contains tab indentation; context: 
```

Is there a reason “; context: ” is always printed there?  It made me think that the tool was broken at first.

Assuming that string isn’t serving a purpose when it’s blank, this PR removes it in that case.

Also, can this please be backported to `coffeelint@1` and published under `1.16.3` branched from the last `@1` release?  Our projects still use CoffeeScript 1 and `coffeelint@2` seems to have a rough time with our files because of that, so I would need the change deployed on version 1 in order to use it via the usual NPM channel.

Thanks,
Jackson