### PR TITLE
Output more location data in lint errors

### DIFF
--- a/src/lexical_linter.coffee
+++ b/src/lexical_linter.coffee
@@ -43,6 +43,7 @@ module.exports = class LexicalLinter extends BaseLinter
     lintToken: (token) ->
         [type, value, { first_line: lineNumber }] = token
 
+        @token = token
         @tokensByLine[lineNumber] ?= []
         @tokensByLine[lineNumber].push(token)
         # CoffeeScript loses line numbers of interpolations and multi-line
@@ -64,4 +65,5 @@ module.exports = class LexicalLinter extends BaseLinter
         attrs.lineNumber ?= @lineNumber
         attrs.lineNumber += 1
         attrs.line = @tokenApi.lines[attrs.lineNumber - 1]
+        attrs.location ?= @token[2]
         super ruleName, attrs

--- a/src/rules/cyclomatic_complexity.coffee
+++ b/src/rules/cyclomatic_complexity.coffee
@@ -47,6 +47,7 @@ module.exports = class CyclomaticComplexity
                 context: complexity + 1
                 lineNumber: node.locationData.first_line + 1
                 lineNumberEnd: node.locationData.last_line + 1
+                location: node.locationData
             }
             @errors.push error if error
 

--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -63,6 +63,8 @@ module.exports = class Indentation
                         if dotIndent % expected isnt 0
                             return {
                                 context: "Expected #{expected} got #{got}"
+                                expected: expected
+                                actual: got
                             }
 
             return undefined
@@ -97,7 +99,11 @@ module.exports = class Indentation
 
         # Now check the indentation.
         if not ignoreIndent and not (expected in numIndents)
-            return { context: "Expected #{expected} got #{numIndents[0]}" }
+            return {
+                context: "Expected #{expected} got #{numIndents[0]}"
+                expected: expected
+                actual: numIndents[0]
+            }
 
     # Return true if the current token is inside of an array.
     inArray: () ->

--- a/src/rules/missing_fat_arrows.coffee
+++ b/src/rules/missing_fat_arrows.coffee
@@ -49,6 +49,7 @@ module.exports = class MissingFatArrows
                 (@needsFatArrow node)
             error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1
+                location: node.locationData
             @errors.push error
 
         node.eachChild (child) => @lintNode child,

--- a/src/rules/no_empty_functions.coffee
+++ b/src/rules/no_empty_functions.coffee
@@ -41,5 +41,6 @@ module.exports = class NoEmptyFunctions
         if isEmptyCode node, astApi
             error = astApi.createError
                 lineNumber: node.locationData.first_line + 1
+                location: node.locationData
             @errors.push error
         node.eachChild (child) => @lintNode child, astApi

--- a/src/rules/no_private_function_fat_arrows.coffee
+++ b/src/rules/no_private_function_fat_arrows.coffee
@@ -18,6 +18,7 @@ module.exports = class NoPrivateFunctionFatArrows
         if @isFatArrowCode(node) and node in functions
             error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1
+                location: node.locationData
             @errors.push error
 
         node.eachChild (child) => @lintNode child,

--- a/src/rules/no_unnecessary_fat_arrows.coffee
+++ b/src/rules/no_unnecessary_fat_arrows.coffee
@@ -19,6 +19,7 @@ module.exports = class NoUnnecessaryFatArrows
         if (@isFatArrowCode node) and (not @needsFatArrow node)
             error = @astApi.createError
                 lineNumber: node.locationData.first_line + 1
+                location: node.locationData
             @errors.push error
         node.eachChild (child) => @lintNode child
 


### PR DESCRIPTION
I've been working on an automated lint error fixer. Basically it takes the output from Coffeelint and programmatically fixes the errors when possible (e.g. for errors like no_unnecessary_fat_arrows where the intent is obvious and the fix is simple).

This change enables the automated fixer, which relies on this fine-grain error location data. I also add 'expected' and 'actual' indentation information, which is useful in fixing indentation errors.

I had to add location manually to each AST rule, since the rule itself is responsible for recursing into the AST. On the other hand, we can inject location data for all token based linters in the lexical_linter.coffee file.

I could create a separate pull request for my fixer script, which currently supports fixes for the following error types:
- indentation
- no_trailing_whitespace
- no_trailing_semicolons
- no_unnecessary_double_quotes
- space_operators
- spacing_after_comma
- colon_assignment_spacing
- no_unnecessary_fat_arrows
- arrow_spacing
