### PR TITLE
Fix missing colon in docs in 'coffeelint: disable-line=...'

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,7 +881,7 @@ and warns that line numbers are probably incorrect.
           <p>
               This version updates the enable/disable directives. In addition to
               the existing <tt># coffeelint: disable=rule_name</tt> you can also
-              use <tt># coffeelint disable-line=rule_name</tt>. The rule name is
+              use <tt># coffeelint: disable-line=rule_name</tt>. The rule name is
               still optional in both cases, and you can enable the rules using
               the same syntax.
             </p>


### PR DESCRIPTION
I've copied and pasted the wrong syntax multiple times throughout years wondering why it doesn't work.
Nobody should waste time due to a typo :)