### PR TITLE
Fix 2021

### DIFF
--- a/src/rules/max_line_length.coffee
+++ b/src/rules/max_line_length.coffee
@@ -37,9 +37,16 @@ module.exports = class MaxLineLength
         if max and max < lineLength and not regexes.longUrlComment.test(line)
 
             unless limitComments
-                if lineApi.getLineTokens().length is 0
-                    return
-
+                lineTokens = lineApi.getLineTokens()
+                hasNoCode = (lineTokens.length is 0) ||
+                    (lineTokens[0][0] == 'JS' &&
+                    lineTokens[0][2].first_column ==
+                        lineTokens[0][2].last_column &&
+                    lineTokens[0][2].first_line == lineTokens[0][2].last_line &&
+                        (lineTokens.length is 1 ||
+                        (lineTokens[1][0] == 'TERMINATOR' &&
+                            lineTokens[1][1] ==  '\n')))
+                return false if hasNoCode
             return {
                 context: "Length is #{lineLength}, max is #{max}"
             }

--- a/src/rules/no_interpolation_in_single_quotes.coffee
+++ b/src/rules/no_interpolation_in_single_quotes.coffee
@@ -22,5 +22,6 @@ module.exports = class NoInterpolationInSingleQuotes
 
     lintToken: (token, tokenApi) ->
         tokenValue = token[1]
-        hasInterpolation = tokenValue.match(/^\'.*#\{[^}]+\}.*\'$/)
-        return hasInterpolation
+        hasInterpolation = tokenValue.match(/^\".*#\{[^}]+\}.*\"$/)
+        isSingleQuoted = ["'", "'''"].includes tokenValue.quote
+        return hasInterpolation && isSingleQuoted

--- a/src/rules/no_unnecessary_double_quotes.coffee
+++ b/src/rules/no_unnecessary_double_quotes.coffee
@@ -33,9 +33,7 @@ module.exports = class NoUnnecessaryDoubleQuotes
         if type in ['STRING_START', 'STRING_END']
             return @trackParens arguments...
 
-        stringValue = tokenValue.match(/^\"(.*)\"$/)
-
-        return false unless stringValue # no double quotes, all OK
+        return false if ["'", "'''"].includes tokenValue.quote
 
         # When CoffeeScript generates calls to RegExp it double quotes the 2nd
         # parameter. Using peek(2) becuase the peek(1) would be a CALL_END


### PR DESCRIPTION
The 3 rules didn't work. 
`no_interpolation_in_single_quotes` and `no_unnecessary_double_quotes` because `CoffeeScript.tokens` now always replaces `'` with `"` and checking if string is single quoted must be performed in a different way (see code).

`max_line_length` because `CoffeeScript.tokens` now returns tokens even for an empty line.